### PR TITLE
Add Python control-side bindings (pyarco)

### DIFF
--- a/apps/test/python/init.py
+++ b/apps/test/python/init.py
@@ -1,0 +1,1443 @@
+import os
+import sys
+import math
+
+sys.path.insert(0, os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../../pyarco")))
+
+from nicegui import ui, app, run
+
+import arco
+from arco import (
+    Sine,
+    Sineb,
+    Const,
+    Smoothb,
+    Fader,
+    Delay,
+    Feedback,
+    Allpass,
+    Reson,
+    Lowpass,
+    Blend,
+    Sum,
+    Mix,
+    Route,
+    Pwl,
+    Pwlb,
+    Pwe,
+    Pweb,
+    Pv,
+    Granstream,
+    Ola_pitch_shift,
+    Math,
+    Mathb,
+    Unary,
+    Unaryb,
+    Multx,
+    Tableosc,
+    Tableoscb,
+    Dnsampleb,
+    Dualslewb,
+    Flsyn,
+    Stdistr,
+    Vu,
+    Trig,
+    Yin,
+    Chorddetect,
+    SpectralCentroid,
+    SpectralRolloff,
+    Zero,
+    Zerob,
+    A_RATE,
+    B_RATE,
+    C_RATE,
+    AR,
+    FADE_LINEAR,
+    FADE_EXPONENTIAL,
+    FADE_LOWPASS,
+    FADE_SMOOTH,
+    BLEND_LINEAR,
+    BLEND_POWER,
+    BLEND_45,
+    MATH_OP_MUL,
+    MATH_OP_ADD,
+    MATH_OP_SUB,
+    MATH_OP_DIV,
+    MATH_OP_MAX,
+    MATH_OP_MIN,
+    MATH_OP_CLP,
+    MATH_OP_POW,
+    DNSAMPLE_BASIC,
+    DNSAMPLE_AVG,
+    DNSAMPLE_PEAK,
+    DNSAMPLE_RMS,
+    ACTION_END,
+    ACTION_TERM,
+    ACTION_END_OR_TERM,
+    MUTE,
+    FINISH,
+    create_fader,
+    hz_to_step,
+    step_to_hz,
+    vel_to_linear,
+    db_to_linear,
+    pan_linear,
+    pan_eqlpow,
+    pan_45,
+    max_chans,
+    ArcoEngine,
+    OUTPUT_ID,
+)
+
+# ═══════════════════════ State management ═══════════════════════
+
+
+class DemoState:
+    """Holds all active UGens and connection status."""
+
+    def __init__(self):
+        self.connected = False
+        self.engine = None
+        self.active_ugens = {}  # tag -> {'ugen': Ugen, 'playing': bool, ...}
+        self._counter = 0
+
+    def tag(self, prefix="ugen"):
+        self._counter += 1
+        return f"{prefix}_{self._counter}"
+
+    def register(self, tag, ugen, playing=False, **extra):
+        self.active_ugens[tag] = {'ugen': ugen, 'playing': playing, **extra}
+
+    def get(self, tag):
+        return self.active_ugens.get(tag)
+
+    def remove(self, tag):
+        entry = self.active_ugens.pop(tag, None)
+        if entry and entry['playing']:
+            try:
+                entry['ugen'].mute()
+            except Exception:
+                pass
+        return entry
+
+    def connect(self):
+        if not self.connected:
+            try:
+                self.engine = ArcoEngine()
+                self.engine.connect()
+                self.connected = True
+            except Exception as e:
+                self._connect_error = str(e)
+        return self.connected
+
+
+state = DemoState()
+
+# ═══════════════════════ UI helpers ═══════════════════════
+
+
+def status_chip(playing: bool):
+    if playing:
+        return '🔊 Playing'
+    return '🔇 Stopped'
+
+
+def ensure_connected():
+    if not state.connected:
+        ui.notify('Not connected to Arco server. Click Connect first.',
+                  type='warning')
+        return False
+    return True
+
+
+def make_card_header(title, description=''):
+    with ui.row().classes('items-center gap-2 w-full'):
+        ui.label(title).classes('text-lg font-bold')
+        if description:
+            ui.label(description).classes('text-xs text-gray-500')
+
+
+# ═══════════════════════ Oscillator demos ═══════════════════════
+
+
+def sine_demo():
+    tag = state.tag('sine')
+    ugen_ref = {'obj': None, 'playing': False}
+    status_label = None
+
+    with ui.card().classes('w-full'):
+        make_card_header('Sine', 'Audio-rate sine oscillator')
+        ui.separator()
+
+        freq_slider = ui.slider(min=20, max=4000, value=440, step=1) \
+            .props('label-always').classes('w-full')
+        ui.label().bind_text_from(freq_slider,
+                                  'value',
+                                  backward=lambda v: f'Frequency: {v} Hz')
+
+        amp_slider = ui.slider(min=0, max=1.0, value=0.3, step=0.01) \
+            .props('label-always').classes('w-full')
+        ui.label().bind_text_from(amp_slider,
+                                  'value',
+                                  backward=lambda v: f'Amplitude: {v:.2f}')
+
+        with ui.row().classes('items-center gap-4'):
+            status_label = ui.label(status_chip(False))
+
+            def toggle_play():
+                if not ensure_connected():
+                    return
+                if ugen_ref['playing']:
+                    ugen_ref['obj'].mute()
+                    ugen_ref['playing'] = False
+                    state.active_ugens[tag]['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if ugen_ref['obj'] is None:
+                        ugen_ref['obj'] = Sine(freq_slider.value,
+                                               amp_slider.value)
+                        state.register(tag, ugen_ref['obj'])
+                    ugen_ref['obj'].play()
+                    ugen_ref['playing'] = True
+                    state.active_ugens[tag]['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle_play) \
+                .props('color=primary')
+
+            def cleanup():
+                if ugen_ref['obj'] is not None:
+                    state.remove(tag)
+                    ugen_ref['obj'] = None
+                    ugen_ref['playing'] = False
+                    status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        def on_freq_change(e):
+            if ugen_ref['obj'] and ugen_ref['playing']:
+                ugen_ref['obj'].set('freq', e.args)
+
+        def on_amp_change(e):
+            if ugen_ref['obj'] and ugen_ref['playing']:
+                ugen_ref['obj'].set('amp', e.args)
+
+        freq_slider.on('update:model-value', on_freq_change)
+        amp_slider.on('update:model-value', on_amp_change)
+
+
+def tableosc_demo():
+    tag = state.tag('tableosc')
+    ugen_ref = {'obj': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header('Tableosc', 'Wavetable oscillator')
+        ui.separator()
+
+        freq_slider = ui.slider(min=20, max=4000, value=440, step=1) \
+            .classes('w-full')
+        ui.label().bind_text_from(freq_slider,
+                                  'value',
+                                  backward=lambda v: f'Frequency: {v} Hz')
+
+        amp_slider = ui.slider(min=0, max=1.0, value=0.3, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(amp_slider,
+                                  'value',
+                                  backward=lambda v: f'Amplitude: {v:.2f}')
+
+        harmonics_slider = ui.slider(min=1, max=32, value=8, step=1) \
+            .classes('w-full')
+        ui.label().bind_text_from(harmonics_slider,
+                                  'value',
+                                  backward=lambda v: f'Harmonics: {v}')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def toggle_play():
+                if not ensure_connected():
+                    return
+                if ugen_ref['playing']:
+                    ugen_ref['obj'].mute()
+                    ugen_ref['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if ugen_ref['obj'] is None:
+                        t = Tableosc(freq_slider.value, amp_slider.value)
+                        n = int(harmonics_slider.value)
+                        ampspec = [1.0 / (i + 1) for i in range(n)]
+                        t.create_tas(0, max(512, 16 * n), ampspec)
+                        t.select(0)
+                        ugen_ref['obj'] = t
+                        state.register(tag, t)
+                    ugen_ref['obj'].play()
+                    ugen_ref['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle_play) \
+                .props('color=primary')
+
+            def cleanup():
+                if ugen_ref['obj'] is not None:
+                    state.remove(tag)
+                    ugen_ref['obj'] = None
+                    ugen_ref['playing'] = False
+                    status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        def on_freq(e):
+            if ugen_ref['obj'] and ugen_ref['playing']:
+                ugen_ref['obj'].set('freq', e.args)
+
+        def on_amp(e):
+            if ugen_ref['obj'] and ugen_ref['playing']:
+                ugen_ref['obj'].set('amp', e.args)
+
+        freq_slider.on('update:model-value', on_freq)
+        amp_slider.on('update:model-value', on_amp)
+
+
+# ═══════════════════════ Filter demos ═══════════════════════
+
+
+def lowpass_demo():
+    tag = state.tag('lowpass')
+    refs = {'source': None, 'filter': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header('Lowpass',
+                         'First-order lowpass filter on a sine source')
+        ui.separator()
+
+        src_freq = ui.slider(min=20, max=4000, value=440,
+                             step=1).classes('w-full')
+        ui.label().bind_text_from(src_freq,
+                                  'value',
+                                  backward=lambda v: f'Source freq: {v} Hz')
+
+        cutoff_slider = ui.slider(min=20, max=16000, value=2000, step=10) \
+            .classes('w-full')
+        ui.label().bind_text_from(cutoff_slider,
+                                  'value',
+                                  backward=lambda v: f'Cutoff: {v} Hz')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['playing']:
+                    refs['filter'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if refs['source'] is None:
+                        refs['source'] = Sine(src_freq.value, 0.4)
+                        refs['filter'] = Lowpass(refs['source'],
+                                                 cutoff_slider.value)
+                        state.register(tag, refs['filter'])
+                    refs['filter'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(source=None, filter=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        def on_cutoff(e):
+            if refs['filter'] and refs['playing']:
+                refs['filter'].set('cutoff', e.args)
+
+        def on_src(e):
+            if refs['source'] and refs['playing']:
+                refs['source'].set('freq', e.args)
+
+        cutoff_slider.on('update:model-value', on_cutoff)
+        src_freq.on('update:model-value', on_src)
+
+
+def reson_demo():
+    tag = state.tag('reson')
+    refs = {'source': None, 'filter': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header('Reson', 'Resonant bandpass filter')
+        ui.separator()
+
+        src_freq = ui.slider(min=20, max=4000, value=220,
+                             step=1).classes('w-full')
+        ui.label().bind_text_from(src_freq,
+                                  'value',
+                                  backward=lambda v: f'Source freq: {v} Hz')
+
+        center_slider = ui.slider(min=20, max=8000, value=880, step=10) \
+            .classes('w-full')
+        ui.label().bind_text_from(center_slider,
+                                  'value',
+                                  backward=lambda v: f'Center: {v} Hz')
+
+        q_slider = ui.slider(min=0.5, max=100, value=10, step=0.5) \
+            .classes('w-full')
+        ui.label().bind_text_from(q_slider,
+                                  'value',
+                                  backward=lambda v: f'Q: {v:.1f}')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['playing']:
+                    refs['filter'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if refs['source'] is None:
+                        refs['source'] = Sine(src_freq.value, 0.3)
+                        refs['filter'] = Reson(refs['source'],
+                                               center_slider.value,
+                                               q_slider.value)
+                        state.register(tag, refs['filter'])
+                    refs['filter'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(source=None, filter=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        def on_center(e):
+            if refs['filter'] and refs['playing']:
+                refs['filter'].set('center', e.args)
+
+        def on_q(e):
+            if refs['filter'] and refs['playing']:
+                refs['filter'].set('q', e.args)
+
+        center_slider.on('update:model-value', on_center)
+        q_slider.on('update:model-value', on_q)
+
+
+def allpass_demo():
+    tag = state.tag('allpass')
+    refs = {'source': None, 'effect': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header(
+            'Allpass',
+            'Allpass delay -- adds phase shift without changing amplitude spectrum'
+        )
+        ui.separator()
+
+        src_freq = ui.slider(min=100, max=2000, value=440, step=1) \
+            .classes('w-full')
+        ui.label().bind_text_from(src_freq,
+                                  'value',
+                                  backward=lambda v: f'Source freq: {v} Hz')
+
+        dur_slider = ui.slider(min=0.001, max=0.1, value=0.01, step=0.001) \
+            .classes('w-full')
+        ui.label().bind_text_from(dur_slider,
+                                  'value',
+                                  backward=lambda v: f'Delay: {v:.3f} s')
+
+        fb_slider = ui.slider(min=0, max=0.95, value=0.7, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(fb_slider,
+                                  'value',
+                                  backward=lambda v: f'Feedback: {v:.2f}')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['playing']:
+                    refs['effect'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if refs['source'] is None:
+                        refs['source'] = Sine(src_freq.value, 0.3)
+                        refs['effect'] = Allpass(refs['source'],
+                                                 dur_slider.value,
+                                                 fb_slider.value, 0.2)
+                        state.register(tag, refs['effect'])
+                    refs['effect'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(source=None, effect=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        def on_dur(e):
+            if refs['effect'] and refs['playing']:
+                refs['effect'].set('dur', e.args)
+
+        def on_fb(e):
+            if refs['effect'] and refs['playing']:
+                refs['effect'].set('fb', e.args)
+
+        dur_slider.on('update:model-value', on_dur)
+        fb_slider.on('update:model-value', on_fb)
+
+
+# ═══════════════════════ Effects demos ═══════════════════════
+
+
+def delay_demo():
+    tag = state.tag('delay')
+    refs = {'source': None, 'effect': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header('Delay', 'Delay line with feedback')
+        ui.separator()
+
+        src_freq = ui.slider(min=100, max=2000, value=440,
+                             step=1).classes('w-full')
+        ui.label().bind_text_from(src_freq,
+                                  'value',
+                                  backward=lambda v: f'Source freq: {v} Hz')
+
+        dur_slider = ui.slider(min=0.01, max=1.0, value=0.25, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(dur_slider,
+                                  'value',
+                                  backward=lambda v: f'Delay: {v:.2f} s')
+
+        fb_slider = ui.slider(min=0, max=0.95, value=0.5, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(fb_slider,
+                                  'value',
+                                  backward=lambda v: f'Feedback: {v:.2f}')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['playing']:
+                    refs['effect'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if refs['source'] is None:
+                        refs['source'] = Sine(src_freq.value, 0.3)
+                        refs['effect'] = Delay(refs['source'],
+                                               dur_slider.value,
+                                               fb_slider.value, 1.0)
+                        state.register(tag, refs['effect'])
+                    refs['effect'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(source=None, effect=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        def on_dur(e):
+            if refs['effect'] and refs['playing']:
+                refs['effect'].set('dur', e.args)
+
+        def on_fb(e):
+            if refs['effect'] and refs['playing']:
+                refs['effect'].set('fb', e.args)
+
+        dur_slider.on('update:model-value', on_dur)
+        fb_slider.on('update:model-value', on_fb)
+
+
+def blend_demo():
+    tag = state.tag('blend')
+    refs = {'s1': None, 's2': None, 'blend': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header('Blend', 'Crossfade between two sine sources')
+        ui.separator()
+
+        freq1 = ui.slider(min=100, max=2000, value=440,
+                          step=1).classes('w-full')
+        ui.label().bind_text_from(freq1,
+                                  'value',
+                                  backward=lambda v: f'Source 1 freq: {v} Hz')
+
+        freq2 = ui.slider(min=100, max=2000, value=660,
+                          step=1).classes('w-full')
+        ui.label().bind_text_from(freq2,
+                                  'value',
+                                  backward=lambda v: f'Source 2 freq: {v} Hz')
+
+        b_slider = ui.slider(min=0, max=1.0, value=0.5, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(
+            b_slider,
+            'value',
+            backward=lambda v: f'Blend: {v:.2f} (0=src1, 1=src2)')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['playing']:
+                    refs['blend'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if refs['s1'] is None:
+                        refs['s1'] = Sine(freq1.value, 0.4)
+                        refs['s2'] = Sine(freq2.value, 0.4)
+                        refs['blend'] = Blend(refs['s1'], refs['s2'],
+                                              b_slider.value, BLEND_POWER)
+                        state.register(tag, refs['blend'])
+                    refs['blend'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(s1=None, s2=None, blend=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        def on_blend(e):
+            if refs['blend'] and refs['playing']:
+                refs['blend'].set('b', e.args)
+
+        b_slider.on('update:model-value', on_blend)
+
+
+def pitch_shift_demo():
+    tag = state.tag('pitchshift')
+    refs = {'source': None, 'effect': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header('OLA Pitch Shift', 'Overlap-add pitch shifting')
+        ui.separator()
+
+        src_freq = ui.slider(min=100, max=2000, value=440,
+                             step=1).classes('w-full')
+        ui.label().bind_text_from(src_freq,
+                                  'value',
+                                  backward=lambda v: f'Source freq: {v} Hz')
+
+        ratio_slider = ui.slider(min=0.5, max=2.0, value=1.0, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(ratio_slider,
+                                  'value',
+                                  backward=lambda v: f'Ratio: {v:.2f}x')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['playing']:
+                    refs['effect'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if refs['source'] is None:
+                        refs['source'] = Sine(src_freq.value, 0.3)
+                        refs['effect'] = Ola_pitch_shift(
+                            refs['source'], ratio_slider.value, 0.02, 0.04)
+                        state.register(tag, refs['effect'])
+                    refs['effect'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(source=None, effect=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        def on_ratio(e):
+            if refs['effect'] and refs['playing']:
+                refs['effect'].set_ratio(e.args)
+
+        ratio_slider.on('update:model-value', on_ratio)
+
+
+def granstream_demo():
+    tag = state.tag('granstream')
+    refs = {'source': None, 'effect': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header('Granstream', 'Granular synthesis on a live source')
+        ui.separator()
+
+        src_freq = ui.slider(min=100, max=2000, value=220,
+                             step=1).classes('w-full')
+        ui.label().bind_text_from(src_freq,
+                                  'value',
+                                  backward=lambda v: f'Source freq: {v} Hz')
+
+        density_slider = ui.slider(min=1, max=50, value=10, step=1) \
+            .classes('w-full')
+        ui.label().bind_text_from(density_slider,
+                                  'value',
+                                  backward=lambda v: f'Density: {v}')
+
+        dur_slider = ui.slider(min=0.01, max=0.5, value=0.1, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(dur_slider,
+                                  'value',
+                                  backward=lambda v: f'Grain dur: {v:.2f} s')
+
+        ratio_lo = ui.slider(min=0.5, max=2.0, value=0.8, step=0.05) \
+            .classes('w-full')
+        ui.label().bind_text_from(ratio_lo,
+                                  'value',
+                                  backward=lambda v: f'Ratio low: {v:.2f}')
+
+        ratio_hi = ui.slider(min=0.5, max=2.0, value=1.2, step=0.05) \
+            .classes('w-full')
+        ui.label().bind_text_from(ratio_hi,
+                                  'value',
+                                  backward=lambda v: f'Ratio high: {v:.2f}')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['playing']:
+                    refs['effect'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if refs['source'] is None:
+                        refs['source'] = Sine(src_freq.value, 0.3)
+                        refs['effect'] = Granstream(refs['source'],
+                                                    int(density_slider.value),
+                                                    dur_slider.value, True)
+                        refs['effect'].set_ratio(ratio_lo.value,
+                                                 ratio_hi.value)
+                        state.register(tag, refs['effect'])
+                    refs['effect'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(source=None, effect=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        def on_density(e):
+            if refs['effect'] and refs['playing']:
+                refs['effect'].set_density(e.args)
+
+        def on_dur(e):
+            if refs['effect'] and refs['playing']:
+                refs['effect'].set_dur(e.args)
+
+        def on_ratio(e):
+            if refs['effect'] and refs['playing']:
+                refs['effect'].set_ratio(ratio_lo.value, ratio_hi.value)
+
+        density_slider.on('update:model-value', on_density)
+        dur_slider.on('update:model-value', on_dur)
+        ratio_lo.on('update:model-value', on_ratio)
+        ratio_hi.on('update:model-value', on_ratio)
+
+
+# ═══════════════════════ Envelope demos ═══════════════════════
+
+
+def pwl_demo():
+    tag = state.tag('pwl')
+    refs = {'source': None, 'env': None, 'out': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header(
+            'PWL / PWE',
+            'Piecewise linear or exponential envelope applied to sine')
+        ui.separator()
+
+        freq_slider = ui.slider(min=100, max=2000, value=440,
+                                step=1).classes('w-full')
+        ui.label().bind_text_from(freq_slider,
+                                  'value',
+                                  backward=lambda v: f'Frequency: {v} Hz')
+
+        attack_slider = ui.slider(min=0.001, max=1.0, value=0.05, step=0.001) \
+            .classes('w-full')
+        ui.label().bind_text_from(attack_slider,
+                                  'value',
+                                  backward=lambda v: f'Attack: {v:.3f} s')
+
+        sustain_slider = ui.slider(min=0.01, max=3.0, value=0.5, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(sustain_slider,
+                                  'value',
+                                  backward=lambda v: f'Sustain: {v:.2f} s')
+
+        release_slider = ui.slider(min=0.01, max=2.0, value=0.3, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(release_slider,
+                                  'value',
+                                  backward=lambda v: f'Release: {v:.2f} s')
+
+        env_type = ui.toggle({
+            0: 'PWL (linear)',
+            1: 'PWE (exponential)'
+        },
+                             value=0).classes('w-full')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def trigger():
+                if not ensure_connected():
+                    return
+
+                # Clean up previous envelope/output to avoid leaking UGens
+                if refs['out'] is not None:
+                    try:
+                        refs['out'].mute()
+                    except Exception:
+                        pass
+                    refs['out'] = None
+                    refs['env'] = None
+
+                atk = attack_slider.value
+                sus = sustain_slider.value
+                rel = release_slider.value
+                points = [atk, 1.0, sus, 1.0, rel, 0.0]
+
+                if refs['source'] is None:
+                    refs['source'] = Sine(freq_slider.value, 1.0)
+
+                if env_type.value == 0:
+                    refs['env'] = Pwl(points, start=False)
+                else:
+                    refs['env'] = Pwe(points, initial_value=0.001, start=False)
+
+                refs['out'] = Math.mult(refs['source'], refs['env'])
+                refs['out'].play()
+                refs['env'].start()
+                refs['playing'] = True
+                state.register(tag, refs['out'], playing=True)
+                status_label.set_text(status_chip(True))
+
+            ui.button('Trigger Envelope', on_click=trigger) \
+                .props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(source=None, env=None, out=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+
+# ═══════════════════════ Mixing demos ═══════════════════════
+
+
+def fader_demo():
+    tag = state.tag('fader')
+    refs = {'source': None, 'fader': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header('Fader', 'Smooth amplitude fading')
+        ui.separator()
+
+        freq_slider = ui.slider(min=100, max=2000, value=440,
+                                step=1).classes('w-full')
+        ui.label().bind_text_from(freq_slider,
+                                  'value',
+                                  backward=lambda v: f'Frequency: {v} Hz')
+
+        goal_slider = ui.slider(min=0, max=1.0, value=0.5, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(goal_slider,
+                                  'value',
+                                  backward=lambda v: f'Goal: {v:.2f}')
+
+        dur_slider = ui.slider(min=0.01, max=5.0, value=1.0, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(
+            dur_slider,
+            'value',
+            backward=lambda v: f'Fade duration: {v:.2f} s')
+
+        mode_select = ui.toggle(
+            {
+                FADE_LINEAR: 'Linear',
+                FADE_EXPONENTIAL: 'Exp',
+                FADE_LOWPASS: 'Lowpass',
+                FADE_SMOOTH: 'Smooth'
+            },
+            value=FADE_SMOOTH).classes('w-full')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['playing']:
+                    refs['fader'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if refs['source'] is None:
+                        refs['source'] = Sine(freq_slider.value, 1.0)
+                        refs['fader'] = Fader(refs['source'], 0.0,
+                                              mode_select.value)
+                        state.register(tag, refs['fader'])
+                    refs['fader'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def apply_fade():
+                if refs['fader'] and refs['playing']:
+                    refs['fader'].set_dur(dur_slider.value)
+                    refs['fader'].set_mode(mode_select.value)
+                    refs['fader'].set_goal(goal_slider.value)
+
+            ui.button('Apply Fade', on_click=apply_fade) \
+                .props('color=accent')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(source=None, fader=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+
+def sum_demo():
+    tag = state.tag('sum')
+    refs = {'sources': [], 'mixer': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header('Sum', 'Additive mixer -- stack multiple sines')
+        ui.separator()
+
+        freq_input = ui.number('Frequency (Hz)', value=440, min=20, max=4000)
+        amp_input = ui.number('Amplitude',
+                              value=0.2,
+                              min=0,
+                              max=1.0,
+                              step=0.05)
+        source_list = ui.label('Sources: (none)')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def add_source():
+                if not ensure_connected():
+                    return
+                if refs['mixer'] is None:
+                    refs['mixer'] = Sum(1)
+                    state.register(tag, refs['mixer'])
+                s = Sine(freq_input.value, amp_input.value)
+                refs['sources'].append(s)
+                refs['mixer'].ins(s)
+                source_list.set_text(
+                    f"Sources: {len(refs['sources'])} sine(s)")
+
+            ui.button('Add Sine', on_click=add_source).props('color=accent')
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['mixer'] is None:
+                    ui.notify('Add at least one source first', type='info')
+                    return
+                if refs['playing']:
+                    refs['mixer'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    refs['mixer'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(sources=[], mixer=None, playing=False)
+                source_list.set_text('Sources: (none)')
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy All', on_click=cleanup) \
+                .props('color=negative outline')
+
+
+def fade_demo():
+    tag = state.tag('fade')
+    refs = {'source': None, 'playing': False}
+
+    with ui.card().classes('w-full'):
+        make_card_header('Fade In / Out',
+                         'Demonstrate ugen.fade_in() and ugen.fade()')
+        ui.separator()
+
+        freq_slider = ui.slider(min=100, max=2000, value=440, step=1) \
+            .classes('w-full')
+        ui.label().bind_text_from(freq_slider,
+                                  'value',
+                                  backward=lambda v: f'Frequency: {v} Hz')
+
+        dur_slider = ui.slider(min=0.1, max=5.0, value=1.0, step=0.1) \
+            .classes('w-full')
+        ui.label().bind_text_from(
+            dur_slider,
+            'value',
+            backward=lambda v: f'Fade duration: {v:.1f} s')
+
+        mode_select = ui.toggle(
+            {
+                FADE_LINEAR: 'Linear',
+                FADE_EXPONENTIAL: 'Exp',
+                FADE_LOWPASS: 'Lowpass',
+                FADE_SMOOTH: 'Smooth'
+            },
+            value=FADE_SMOOTH).classes('w-full')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def do_fade_in():
+                if not ensure_connected():
+                    return
+                if refs['source'] is None:
+                    refs['source'] = Sine(freq_slider.value, 0.4)
+                    state.register(tag, refs['source'])
+                refs['source'].fade_in(dur_slider.value,
+                                       mode=mode_select.value)
+                refs['playing'] = True
+                status_label.set_text(status_chip(True))
+                ui.notify(f'Fading in over {dur_slider.value:.1f}s',
+                          type='info')
+
+            ui.button('Fade In', on_click=do_fade_in) \
+                .props('color=primary')
+
+            def do_fade_out():
+                if refs['source'] is not None and refs['playing']:
+                    refs['source'].fade(dur_slider.value,
+                                        mode=mode_select.value)
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                    ui.notify(f'Fading out over {dur_slider.value:.1f}s',
+                              type='info')
+
+            ui.button('Fade Out', on_click=do_fade_out) \
+                .props('color=secondary')
+
+            def cleanup():
+                if refs['source'] is not None:
+                    try:
+                        refs['source'].mute()
+                    except Exception:
+                        pass
+                state.remove(tag)
+                refs.update(source=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        ui.label('Fade In smoothly connects the source to audio output; '
+                 'Fade Out smoothly disconnects it.') \
+            .classes('text-xs text-gray-400 italic')
+
+
+def mix_demo():
+    tag = state.tag('mix')
+    refs = {'sources': {}, 'mixer': None, 'playing': False, 'counter': 0}
+
+    with ui.card().classes('w-full'):
+        make_card_header('Mix',
+                         'Named-input mixer with per-channel gain control')
+        ui.separator()
+
+        freq_input = ui.number('Frequency (Hz)', value=440, min=20, max=4000)
+        gain_input = ui.number('Gain', value=0.3, min=0, max=1.0, step=0.05)
+        source_list = ui.label('Inputs: (none)')
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def add_source():
+                if not ensure_connected():
+                    return
+                if refs['mixer'] is None:
+                    refs['mixer'] = Mix(1)
+                    state.register(tag, refs['mixer'])
+                refs['counter'] += 1
+                name = f's{refs["counter"]}'
+                s = Sine(freq_input.value, 1.0)
+                refs['sources'][name] = s
+                refs['mixer'].ins(name, s, gain_input.value)
+                source_list.set_text(
+                    f"Inputs: {', '.join(refs['sources'].keys())}")
+
+            ui.button('Add Sine', on_click=add_source).props('color=accent')
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['mixer'] is None:
+                    ui.notify('Add at least one input first', type='info')
+                    return
+                if refs['playing']:
+                    refs['mixer'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    refs['mixer'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(sources={}, mixer=None, playing=False, counter=0)
+                source_list.set_text('Inputs: (none)')
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy All', on_click=cleanup) \
+                .props('color=negative outline')
+
+        ui.label('Unlike Sum, Mix supports named inputs and per-input '
+                 'gain with smooth crossfading.') \
+            .classes('text-xs text-gray-400 italic')
+
+
+# ═══════════════════════ Math / Unary demos ═══════════════════════
+
+
+def math_demo():
+    tag = state.tag('math')
+    refs = {'s1': None, 's2': None, 'math': None, 'playing': False}
+
+    MATH_OPS = {
+        'Multiply': arco.MATH_OP_MUL,
+        'Add': arco.MATH_OP_ADD,
+        'Subtract': arco.MATH_OP_SUB,
+        'Divide': arco.MATH_OP_DIV,
+        'Max': arco.MATH_OP_MAX,
+        'Min': arco.MATH_OP_MIN,
+        'Clip': arco.MATH_OP_CLP,
+        'Power': arco.MATH_OP_POW,
+        'Less': arco.MATH_OP_LT,
+        'Greater': arco.MATH_OP_GT,
+        'Soft Clip': arco.MATH_OP_SCP,
+    }
+
+    with ui.card().classes('w-full'):
+        make_card_header('Math', 'Binary math operation on two audio signals')
+        ui.separator()
+
+        op_select = ui.select(list(MATH_OPS.keys()),
+                              value='Multiply',
+                              label='Operation').classes('w-full')
+
+        freq1 = ui.slider(min=20, max=2000, value=440,
+                          step=1).classes('w-full')
+        ui.label().bind_text_from(freq1,
+                                  'value',
+                                  backward=lambda v: f'Source 1: {v} Hz')
+
+        freq2 = ui.slider(min=0.5, max=2000, value=3,
+                          step=0.5).classes('w-full')
+        ui.label().bind_text_from(
+            freq2, 'value', backward=lambda v: f'Source 2: {v} Hz (or LFO)')
+
+        amp2 = ui.slider(min=0, max=1.0, value=0.5,
+                         step=0.01).classes('w-full')
+        ui.label().bind_text_from(amp2,
+                                  'value',
+                                  backward=lambda v: f'Source 2 amp: {v:.2f}')
+
+        status_label = ui.label(status_chip(False))
+
+        with ui.row().classes('items-center gap-4'):
+
+            def toggle():
+                if not ensure_connected():
+                    return
+                if refs['playing']:
+                    refs['math'].mute()
+                    refs['playing'] = False
+                    status_label.set_text(status_chip(False))
+                else:
+                    if refs['s1'] is None:
+                        refs['s1'] = Sine(freq1.value, 0.5)
+                        refs['s2'] = Sine(freq2.value, amp2.value)
+                        op = MATH_OPS[op_select.value]
+                        refs['math'] = Math(op, refs['s1'], refs['s2'])
+                        state.register(tag, refs['math'])
+                    refs['math'].play()
+                    refs['playing'] = True
+                    status_label.set_text(status_chip(True))
+
+            ui.button('Play / Stop', on_click=toggle).props('color=primary')
+
+            def cleanup():
+                state.remove(tag)
+                refs.update(s1=None, s2=None, math=None, playing=False)
+                status_label.set_text(status_chip(False))
+
+            ui.button('Destroy', on_click=cleanup) \
+                .props('color=negative outline')
+
+        ui.label('Tip: For ring modulation, use Multiply with a low-freq '
+                 'Source 2.').classes('text-xs text-gray-400 italic')
+
+
+# ═══════════════════════ Utility demos ═══════════════════════
+
+
+def panning_demo():
+    with ui.card().classes('w-full'):
+        make_card_header('Panning Laws',
+                         'Compare linear, equal-power, and -4.5 dB')
+        ui.separator()
+
+        pan_slider = ui.slider(min=0, max=1.0, value=0.5, step=0.01) \
+            .classes('w-full')
+        ui.label().bind_text_from(
+            pan_slider, 'value', backward=lambda v: f'Pan: {v:.2f} (0=L, 1=R)')
+
+        result_label = ui.label('')
+
+        def update_display(e=None):
+            x = pan_slider.value
+            lin = pan_linear(x)
+            ep = pan_eqlpow(x)
+            p45 = pan_45(x)
+            result_label.set_text(
+                f'Linear: L={lin[0]:.3f}  R={lin[1]:.3f}  |  '
+                f'EqPow: L={ep[0]:.3f}  R={ep[1]:.3f}  |  '
+                f'-4.5dB: L={p45[0]:.3f}  R={p45[1]:.3f}')
+
+        pan_slider.on('update:model-value', update_display)
+        update_display()
+
+
+def pitch_conversion_demo():
+    with ui.card().classes('w-full'):
+        make_card_header('Pitch Conversion', 'Hz / MIDI step / ratio')
+        ui.separator()
+
+        step_slider = ui.slider(min=21, max=108, value=69, step=0.5) \
+            .classes('w-full')
+        ui.label().bind_text_from(step_slider,
+                                  'value',
+                                  backward=lambda v: f'MIDI step: {v}')
+
+        result_label = ui.label('')
+
+        def update(e=None):
+            s = step_slider.value
+            hz = step_to_hz(s)
+            note_names = [
+                'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'
+            ]
+            octave = int(s) // 12 - 1
+            name = note_names[int(s) % 12]
+            result_label.set_text(
+                f'{name}{octave}  |  {hz:.2f} Hz  |  '
+                f'step_to_hz({s}) = {hz:.2f}  |  '
+                f'hz_to_step({hz:.1f}) = {hz_to_step(hz):.2f}')
+
+        step_slider.on('update:model-value', update)
+        update()
+
+
+def velocity_demo():
+    with ui.card().classes('w-full'):
+        make_card_header('Velocity Conversion', 'MIDI velocity / linear / dB')
+        ui.separator()
+
+        vel_slider = ui.slider(min=1, max=127, value=100, step=1) \
+            .classes('w-full')
+        ui.label().bind_text_from(vel_slider,
+                                  'value',
+                                  backward=lambda v: f'MIDI velocity: {v}')
+
+        result_label = ui.label('')
+
+        def update(e=None):
+            v = vel_slider.value
+            lin = vel_to_linear(v)
+            db = arco.vel_to_db(v)
+            result_label.set_text(
+                f'vel={v}  ->  linear={lin:.4f}  ->  dB={db:.2f}')
+
+        vel_slider.on('update:model-value', update)
+        update()
+
+
+# ═══════════════════════ Page layout ═══════════════════════
+
+
+def build_page():
+    ui.colors(primary='#1976D2', secondary='#424242', accent='#82B1FF')
+
+    with ui.header().classes('items-center justify-between bg-primary'):
+        ui.label('Arco Interactive Demo').classes(
+            'text-h5 text-white font-bold')
+        with ui.row().classes('items-center gap-4'):
+            conn_label = ui.label('Disconnected').classes('text-white text-sm')
+
+            async def do_connect():
+                conn_label.set_text('Connecting...')
+                state._connect_error = None
+                await run.io_bound(state.connect)
+                if state.connected:
+                    conn_label.set_text('Connected')
+                    ui.notify('Connected to Arco server', type='positive')
+                elif state._connect_error:
+                    conn_label.set_text('Disconnected')
+                    ui.notify(f'Connection failed: {state._connect_error}',
+                              type='negative')
+                else:
+                    conn_label.set_text('Disconnected')
+
+            ui.button('Connect', on_click=do_connect) \
+                .props('color=white text-color=primary dense')
+
+    with ui.left_drawer(value=True).classes('bg-grey-2') as drawer:
+        ui.label('Categories').classes('text-subtitle1 font-bold q-mb-sm')
+        tabs = ui.tabs().props('vertical').classes('w-full')
+        with tabs:
+            osc_tab = ui.tab('Oscillators', icon='graphic_eq')
+            filt_tab = ui.tab('Filters', icon='tune')
+            fx_tab = ui.tab('Effects', icon='auto_fix_high')
+            env_tab = ui.tab('Envelopes', icon='show_chart')
+            mix_tab = ui.tab('Mixing', icon='merge_type')
+            math_tab = ui.tab('Math', icon='calculate')
+            util_tab = ui.tab('Utilities', icon='build')
+
+    with ui.tab_panels(tabs, value=osc_tab) \
+            .classes('w-full max-w-4xl mx-auto q-pa-md'):
+
+        with ui.tab_panel(osc_tab):
+            ui.label('Oscillators').classes('text-h6 q-mb-md')
+            with ui.column().classes('gap-4 w-full'):
+                sine_demo()
+                tableosc_demo()
+
+        with ui.tab_panel(filt_tab):
+            ui.label('Filters').classes('text-h6 q-mb-md')
+            with ui.column().classes('gap-4 w-full'):
+                lowpass_demo()
+                reson_demo()
+                allpass_demo()
+
+        with ui.tab_panel(fx_tab):
+            ui.label('Effects').classes('text-h6 q-mb-md')
+            with ui.column().classes('gap-4 w-full'):
+                delay_demo()
+                blend_demo()
+                pitch_shift_demo()
+                granstream_demo()
+
+        with ui.tab_panel(env_tab):
+            ui.label('Envelopes').classes('text-h6 q-mb-md')
+            with ui.column().classes('gap-4 w-full'):
+                pwl_demo()
+
+        with ui.tab_panel(mix_tab):
+            ui.label('Mixing').classes('text-h6 q-mb-md')
+            with ui.column().classes('gap-4 w-full'):
+                fader_demo()
+                fade_demo()
+                sum_demo()
+                mix_demo()
+
+        with ui.tab_panel(math_tab):
+            ui.label('Math Operations').classes('text-h6 q-mb-md')
+            with ui.column().classes('gap-4 w-full'):
+                math_demo()
+
+        with ui.tab_panel(util_tab):
+            ui.label('Utilities (no audio)').classes('text-h6 q-mb-md')
+            with ui.column().classes('gap-4 w-full'):
+                panning_demo()
+                pitch_conversion_demo()
+                velocity_demo()
+
+    with ui.footer().classes('bg-grey-3 text-grey-8 text-xs'):
+        ui.label('Arco Sound Synthesis Engine -- Python Interface Demo')
+
+
+# ═══════════════════════ Entry point ═══════════════════════
+
+build_page()
+ui.run(title='Arco Demo', port=8080, reload=False)

--- a/pyarco/arco.py
+++ b/pyarco/arco.py
@@ -1,0 +1,7 @@
+"""Arco Python client -- re-export layer.
+
+Imports everything from arco_engine and arco_ugens so that existing
+``from arco import Sine`` keeps working.
+"""
+from arco_engine import *
+from arco_ugens import *

--- a/pyarco/arco_engine.py
+++ b/pyarco/arco_engine.py
@@ -1,0 +1,415 @@
+import os
+import sys
+import time
+import math
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../apps/test/python")))
+
+from o2lite import O2lite
+
+ZERO_ID = 0  # a single-channel audio source of zero (silence)
+ZEROB_ID = 1  # a single-channel block-rate source of zero
+INPUT_ID = 2  # audio input
+OUTPUT_ID = 3  # audio output (Sum ugen)
+ENSEMBLE = "arco"
+
+AR = 44100.0  # audio rate
+AP = 1 / AR  # audio sample period
+BL = 32
+BL_RECIP = 1 / BL
+BR = AR / BL
+BP = 1 / BR
+
+A_RATE = 'a'
+B_RATE = 'b'
+C_RATE = 'c'
+NO_RATE = ''
+
+FADE_LINEAR = 0
+FADE_EXPONENTIAL = 1
+FADE_LOWPASS = 2
+FADE_SMOOTH = 3
+
+MATH_OP_MUL = 0
+MATH_OP_ADD = 1
+MATH_OP_SUB = 2
+MATH_OP_DIV = 3
+MATH_OP_MAX = 4
+MATH_OP_MIN = 5
+MATH_OP_CLP = 6  # min(max(x, -y), y) i.e. clip if |x| > y
+MATH_OP_POW = 7
+MATH_OP_LT = 8
+MATH_OP_GT = 9
+MATH_OP_SCP = 10
+MATH_OP_PWI = 11
+MATH_OP_RND = 12
+MATH_OP_SH = 13
+MATH_OP_QNT = 14
+MATH_OP_RLI = 15
+MATH_OP_HZDIFF = 16
+MATH_OP_TAN = 17
+MATH_OP_ATAN2 = 18
+MATH_OP_SIN = 19
+MATH_OP_COS = 20
+
+UNARY_OP_ABS = 0
+UNARY_OP_NEG = 1
+UNARY_OP_EXP = 2
+UNARY_OP_LOG = 3
+UNARY_OP_LOG10 = 4
+UNARY_OP_LOG2 = 5
+UNARY_OP_SQRT = 6
+UNARY_OP_STEP_TO_HZ = 7
+UNARY_OP_HZ_TO_STEP = 8
+UNARY_OP_VEL_TO_LINEAR = 9
+UNARY_OP_LINEAR_TO_VEL = 10
+UNARY_OP_DB_TO_LINEAR = 11
+UNARY_OP_LINEAR_TO_DB = 12
+
+DNSAMPLE_BASIC = 0
+DNSAMPLE_AVG = 1
+DNSAMPLE_PEAK = 2
+DNSAMPLE_RMS = 3
+DNSAMPLE_POWER = 4
+DNSAMPLE_LOWPASS500 = 5
+DNSAMPLE_LOWPASS100 = 6
+
+BLEND_LINEAR = 0
+BLEND_POWER = 1
+BLEND_45 = 2
+
+ACTION_ALL = 63
+ACTION_TERM = 1
+ACTION_ERROR = 2
+ACTION_EXCEPT = 4
+ACTION_EVENT = 8
+ACTION_END = 16
+ACTION_REM = 32
+ACTION_FREE = 64
+ACTION_END_OR_TERM = ACTION_END | ACTION_TERM
+
+MUTE = 'mute'
+FINISH = 'finish'
+
+# --------------- Step / frequency conversion utilities ---------------
+
+STEP_P1 = 0.0577622650466621
+STEP_P2 = 2.1011784386926213
+
+
+def hz_to_step(hz):
+    """Convert absolute Hz to step: 440 -> 69 (MIDI A4)."""
+    return (math.log(hz) - STEP_P2) / STEP_P1
+
+
+def step_to_hz(steps):
+    """Convert absolute step to Hz: 69 (MIDI A4) -> 440."""
+    return math.exp(steps * STEP_P1 + STEP_P2)
+
+
+def step_to_ratio(steps):
+    """Convert steps to frequency ratio: 7 -> ~1.5."""
+    return step_to_hz(69 + steps) / 440.0
+
+
+def ratio_to_step(ratio):
+    """Convert frequency ratio to steps: 1.5 -> ~7."""
+    return hz_to_step(ratio * 440.0) - 69
+
+
+def steps_to_hzdiff(steps, delta_steps):
+    """Compute change in Hz when adding delta_steps to steps."""
+    return step_to_hz(steps + delta_steps) - step_to_hz(steps)
+
+
+# --------------- Velocity / dB conversion utilities ---------------
+
+_LOG_OF_10_OVER_20 = math.log(10.0) / 20.0
+
+
+def db_to_linear(x):
+    """Convert dB to linear amplitude."""
+    return math.exp(_LOG_OF_10_OVER_20 * x)
+
+
+def linear_to_db(x):
+    """Convert linear amplitude to dB."""
+    return math.log(x) / _LOG_OF_10_OVER_20
+
+
+def vel_to_linear(v):
+    """Convert MIDI velocity to linear amplitude."""
+    return ((v * 0.00768553) + 0.0239372) ** 2
+
+
+def linear_to_vel(x, use_float=False):
+    """Convert linear amplitude to MIDI velocity."""
+    x = (math.sqrt(abs(x)) - 0.0239372) / 0.00768553
+    if not use_float:
+        x = max(1, min(127, round(x)))
+    return x
+
+
+def vel_to_db(v):
+    """Convert MIDI velocity to dB."""
+    return linear_to_db(vel_to_linear(v))
+
+
+def db_to_vel(x, use_float=False):
+    """Convert dB to MIDI velocity."""
+    return linear_to_vel(db_to_linear(x), use_float)
+
+
+# --------------- Panning utilities ---------------
+
+def pan_linear(x, gain=1):
+    """Linear panning law: x=0 full left, x=1 full right."""
+    x = min(1, max(0, x))
+    return [(1 - x) * gain, x * gain]
+
+
+def pan_eqlpow(x, gain=1):
+    """Equal-power panning law: L^2 + R^2 = 1 (scaled by gain)."""
+    p = pan_linear(x)
+    p[0] = math.sqrt(p[0]) * gain
+    p[1] = math.sqrt(p[1]) * gain
+    return p
+
+
+def pan_45(x, gain=1):
+    """-4.5 dB panning law (geometric mean of linear and equal-power)."""
+    x = min(1, max(0, x))
+    p = pan_linear(x)
+    p[0] = math.sqrt(p[0] * math.sqrt(p[0])) * gain
+    p[1] = math.sqrt(p[1] * math.sqrt(p[1])) * gain
+    return p
+
+
+# --------------- Utilities ---------------
+
+def max_chans(chans, ugen):
+    """Compute the maximum of chans and the channels implied by ugen,
+    where ugen may be a number, array, or Ugen."""
+    if isinstance(ugen, (int, float)):
+        return max(chans, 1)
+    elif isinstance(ugen, list):
+        return max(chans, len(ugen))
+    else:
+        return max(chans, ugen.chans)
+
+
+# --------------- UgenID pool ---------------
+
+class UgenID:
+
+    def __init__(self, size=1000, start_id=100):
+        self.size = size
+        self.start_id = start_id
+        self.array = [None] * size
+        self.free_head = start_id  # Head of the list of free slots
+        for i in range(start_id, size - 1):
+            self.array[i] = i + 1  # Link each slot to the next
+        self.array[size - 1] = None
+
+    def request_slot(self):
+        if self.free_head is None:
+            raise Exception("No free slots available")
+        slot = self.free_head
+        self.free_head = self.array[slot]  # Move head to the next free slot
+        self.array[slot] = None  # Mark the slot as occupied
+        return slot
+
+    def free_slot(self, index):
+        if index < self.start_id or index >= self.size:
+            raise IndexError("Index out of bounds")
+        if self.array[index] is not None:
+            raise Exception("Slot is already free")
+        self.array[index] = self.free_head  # Link freed slot to current head
+        self.free_head = index  # Update the head to the newly freed slot
+
+
+# --- Action registration system ---
+
+class Ugen_action:
+    def __init__(self, target, method):
+        self.target = target  # weak ref via id; caller holds strong ref
+        self.method = method
+
+    def __repr__(self):
+        return f"<Ugen_action {self.target} {self.method!r}>"
+
+
+class Action_list:
+    def __init__(self, action_mask, ugen_actions):
+        self.action_mask = action_mask
+        self.ugen_actions = ugen_actions
+
+
+# --------------- Active engine accessor ---------------
+
+_active_engine = None
+
+
+def get_engine():
+    """Return the active ArcoEngine."""
+    if _active_engine is None:
+        raise RuntimeError(
+            "No active ArcoEngine -- call engine.connect() first")
+    return _active_engine
+
+
+# --------------- ArcoEngine ---------------
+
+class ArcoEngine:
+    """Owns the O2lite connection, UgenID pool, and registry of live ugens."""
+
+    def __init__(self, input_chans=2, output_chans=2, ensemble="arco",
+                 timeout=30):
+        self.input_chans = input_chans
+        self.output_chans = output_chans
+        self.ensemble = ensemble
+        self.timeout = timeout
+        self.o2lite = None
+        self.id_pool = UgenID()
+        self._ugens = {}           # id -> Ugen (strong references)
+        self.action_dict = {}       # action_id -> Action_list
+        self.next_action_id = 1
+        self.fade_in_lookup = {}    # ugen.id -> Fader
+        # System ugen references (set during connect)
+        self.zero = None
+        self.zerob = None
+        self.input = None
+        self.output = None
+
+    def connect(self):
+        """Connect to Arco server, create system ugens, set as active engine."""
+        if self.o2lite is not None:
+            return  # already connected
+        from arco_ugens import Ugen, Sum  # deferred to break circular import
+
+        self.o2lite = O2lite()
+        self.o2lite.initialize(self.ensemble, debug_flags="a")
+        deadline = time.time() + self.timeout
+        while self.o2lite.time_get() < 0:
+            if time.time() > deadline:
+                self.o2lite = None
+                raise TimeoutError(
+                    f"Could not connect to Arco server within "
+                    f"{self.timeout} seconds. Is arcobasic running?")
+            self.o2lite.poll()
+            time.sleep(0.01)
+        print("Connected to ensemble", self.ensemble,
+              "O2time", self.o2lite.time_get())
+
+        # Reset Arco — the host creates system ugens at IDs 0-3 as Thru's.
+        self.o2lite.send_cmd("/arco/reset", 0, "")
+        for _ in range(100):
+            self.o2lite.poll()
+            time.sleep(0.01)
+
+        # Set as active engine BEFORE creating system ugens
+        global _active_engine
+        _active_engine = self
+
+        # System ugen shadows (no_msg=True -- host already created them).
+        # Use id_num to avoid wasting pool slots.
+        self.zero = Ugen("Zero", 1, A_RATE, "", no_msg=True,
+                         engine=self, id_num=ZERO_ID)
+        self.zerob = Ugen("Zerob", 1, B_RATE, "", no_msg=True,
+                          engine=self, id_num=ZEROB_ID)
+        self.input = Ugen("Thru", self.input_chans, A_RATE, "", no_msg=True,
+                          engine=self, id_num=INPUT_ID)
+
+        # Replace host's Thru at OUTPUT_ID with a Sum (play/mute need it).
+        self.o2lite.send_cmd("/arco/free", 0, "i", OUTPUT_ID)
+        self.output = Sum(self.output_chans, True, OUTPUT_ID)
+
+        print("Arco initialized: system ugens created")
+
+    def close(self):
+        """Free all ugens, disconnect, and clear active engine."""
+        if self.o2lite is None:
+            return
+        # Free non-system ugens in reverse creation order
+        for ugen_id in sorted(self._ugens.keys(), reverse=True):
+            ugen = self._ugens[ugen_id]
+            if ugen_id >= 100:  # skip system ugens (0-3)
+                self.send_cmd("/arco/free", 0, "i", ugen_id)
+            ugen.engine = None  # prevent double-free in __del__
+        self._ugens.clear()
+        self.id_pool = UgenID()
+        self.action_dict.clear()
+        self.next_action_id = 1
+        self.fade_in_lookup.clear()
+        self.zero = None
+        self.zerob = None
+        self.input = None
+        self.output = None
+        self.o2lite = None
+        global _active_engine
+        if _active_engine is self:
+            _active_engine = None
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def send_cmd(self, *args):
+        """Send an O2 command, guarding against disconnected state."""
+        if self.o2lite is not None:
+            self.o2lite.send_cmd(*args)
+
+    def poll(self):
+        """Poll the O2lite connection."""
+        if self.o2lite is not None:
+            self.o2lite.poll()
+
+    def register(self, ugen):
+        """Register a ugen in the engine's registry (prevents GC)."""
+        self._ugens[ugen.id] = ugen
+
+    def unregister(self, ugen_id):
+        """Remove a ugen from the registry."""
+        self._ugens.pop(ugen_id, None)
+
+    def register_action(self, ugen, action_mask, target, method):
+        """Register a callback action for ugen events."""
+        action = Ugen_action(target, method)
+        aid = ugen.action_id
+        if aid is not None:
+            action_list = self.action_dict.get(aid)
+            if action_list is None:
+                print("ERROR: register_action - action_id not in action_dict",
+                      aid)
+                return
+            if action_mask != (action_mask & action_list.action_mask):
+                action_list.action_mask = action_list.action_mask | action_mask
+                self.send_cmd("/arco/act", 0, "iii", ugen.id, aid,
+                              action_list.action_mask)
+            action_list.ugen_actions.append(action)
+        else:
+            al = Action_list(action_mask, [action])
+            self.action_dict[self.next_action_id] = al
+            ugen.action_id = self.next_action_id
+            self.send_cmd("/arco/act", 0, "iii", ugen.id,
+                          self.next_action_id, action_mask)
+            self.next_action_id += 1
+
+    def actl_act_handler(self, timestamp, address, types, key, status, uid):
+        """Handler for /actl/act messages from Arco server."""
+        al = self.action_dict.get(key)
+        if al is None:
+            return
+        if status & ACTION_FREE:
+            self.action_dict.pop(key, None)
+            return
+        for ua in al.ugen_actions:
+            if status & al.action_mask:
+                target = ua.target
+                if target is not None and hasattr(target, ua.method):
+                    getattr(target, ua.method)(status)

--- a/pyarco/arco_instr.py
+++ b/pyarco/arco_instr.py
@@ -1,0 +1,822 @@
+import math
+import random
+
+from arco import (
+    Ugen,
+    Const,
+    Smoothb,
+    Const_like,
+    Sum,
+    Sumb,
+    Route,
+    Mix,
+    Delay,
+    Allpass,
+    Lowpass,
+    Sine,
+    Sineb,
+    Tableosc,
+    Tableoscb,
+    Stdistr,
+    Pweb,
+    Blend,
+    Blendb,
+    Math,
+    Mathb,
+    Multx,
+    Addb,
+    Add,
+    max_chans,
+    A_RATE,
+    B_RATE,
+    C_RATE,
+    AR,
+    BR,
+    FADE_SMOOTH,
+    BLEND_POWER,
+    MATH_OP_MUL,
+    MATH_OP_ADD,
+    MATH_OP_SUB,
+    ACTION_REM,
+    ACTION_TERM,
+    ACTION_END,
+    ACTION_END_OR_TERM,
+    step_to_hz,
+    hz_to_step,
+    steps_to_hzdiff,
+    vel_to_linear,
+    pan_45,
+)
+SIGNAL = 'signal'
+GAIN = 'gain'
+BOTH = 'both'
+MUTE = 'mute'
+FINISH = 'finish'
+
+# ======================== Instrument parameter framework =====================
+
+# Stack used during instrument construction (between instr_begin and
+# Instrument.__init__) to collect parameter descriptors.
+_instr_stack = []
+
+
+def instr_begin():
+    """Call at the start of an Instrument subclass __init__."""
+    _instr_stack.append({})
+
+
+def _add_param_descr_to_context(pd, name):
+    context = _instr_stack[-1]
+    if name in context:
+        print("WARNING: Parameter", name, "is already specified. Ignored.")
+    else:
+        context[name] = pd
+    return pd.value
+
+
+def param(name,
+          initial_value,
+          op=None,
+          low=None,
+          high=None,
+          smooth=False,
+          chans=1):
+    """Declare a setable parameter backed by a Const or Smoothb UGen.
+
+    Returns the UGen so it can be wired into the instrument graph.
+    """
+    if isinstance(smooth,
+                  (int, float)) and smooth and not isinstance(smooth, bool):
+        ugen = Smoothb(initial_value, cutoff=smooth)
+    elif smooth:
+        ugen = Smoothb(initial_value)
+    else:
+        ugen = Const(initial_value)
+    pd = Param_descr(ugen, initial_value, op, low, high)
+    _add_param_descr_to_context(pd, name)
+    return ugen
+
+
+def param_map(name, initial_value, subinstr, subinstr_name=None):
+    """Declare a parameter that delegates to a sub-instrument's parameter."""
+    if subinstr_name is None:
+        subinstr_name = name
+    pd = Param_descr(subinstr, initial_value, subinstr_name, None, None)
+    _add_param_descr_to_context(pd, name)
+
+
+def param_method(name, initial_value, method, op=None, low=None, high=None):
+    """Declare a parameter handled by calling a method on the instrument."""
+    pd = Param_descr(method, initial_value, op, low, high)
+    _add_param_descr_to_context(pd, name)
+    return initial_value
+
+
+class Param_descr:
+    """Descriptor for an Instrument parameter -- links a name to a UGen or method."""
+
+    def __init__(self, ugen_method, value, op_name=None, low=None, high=None):
+        self.ugen_method = ugen_method
+        self.value = self.condition(value)
+        self.op_name = op_name
+        self.low = low
+        self.high = high
+
+    def condition(self, x):
+        if self.op_name == 'map' if hasattr(self, 'op_name') else False:
+            x = self.low + (self.high - self.low) * x
+        if hasattr(self, 'low') and self.low is not None:
+            x = max(self.low, x)
+        if hasattr(self, 'high') and self.high is not None:
+            x = min(self.high, x)
+        return x
+
+    def set(self, instr, x, reuse=False):
+        if isinstance(self.ugen_method, Instrument):
+            self.value = x
+            self.ugen_method.set(self.op_name, x)
+        elif isinstance(self.ugen_method, str):
+            self.value = self.condition(x)
+            getattr(instr, self.ugen_method)(self.value, reuse)
+        elif isinstance(self.ugen_method, Const_like):
+            self.value = self.condition(x)
+            self.ugen_method.set(self.value)
+        return self.value
+
+
+class Instrument(Ugen):
+    """An Instrument wraps a UGen graph with named, setable parameters.
+
+    Subclasses call instr_begin() at the top of __init__, build the graph,
+    then call super().__init__(name, output_ugen) at the end.
+    """
+
+    def __init__(self, name, output_ugen, synth=None):
+        self.synth = synth
+        self.mixer_id = None
+        self.user_id = None
+        self.pitch = None
+        self.vel = None
+        self.gain = None
+
+        if synth is not None:
+            self.mixer_id = synth.get_mixer_id()
+
+        self.output = output_ugen
+        # Inherit the output ugen's id so that wiring this Instrument
+        # into the graph is the same as wiring its output.
+        super().__init__(name,
+                         output_ugen.chans,
+                         output_ugen.rate,
+                         "",
+                         no_msg=True)
+        self.id = output_ugen.id
+
+        if len(_instr_stack) == 0:
+            raise RuntimeError(
+                "instr_stack is empty. Did you forget instr_begin()?")
+        self.parameter_bindings = _instr_stack.pop()
+
+    def get(self, input_name):
+        return self.parameter_bindings.get(input_name)
+
+    def set(self, name, value, reuse=False):
+        pd = self.parameter_bindings.get(name)
+        if pd is not None:
+            pd.set(self, value, reuse)
+
+    def finish(self, status, finisher, parameters):
+        if self.synth and (status & ACTION_END_OR_TERM) > 0:
+            self.synth.is_finished(self)
+
+
+# ======================== Note / Score =======================================
+
+
+class Note:
+    """A single note event in a Score."""
+
+    def __init__(self, time, pitch, vel, dur, id=None, **params):
+        self.time = time
+        self.pitch = pitch
+        self.vel = vel
+        self.dur = dur
+        self.id = id
+        self.params = params
+
+    def play(self, synth):
+        synth.noteon(self.pitch,
+                     self.vel,
+                     dur=self.dur,
+                     id=self.id,
+                     pdict=self.params)
+
+    def __repr__(self):
+        return (f"Note(t={self.time}, p={self.pitch}, v={self.vel}, "
+                f"d={self.dur}, id={self.id})")
+
+
+class Score:
+    """An ordered list of Notes with scheduled playback."""
+
+    def __init__(self, notes=None):
+        self.notes = notes or []
+        self.time = 0
+        self.dur = 0
+
+    def append_rest(self, dur):
+        self.dur += dur
+
+    def merge(self, score_or_note, offset=0):
+        if isinstance(score_or_note, Score):
+            for note in score_or_note.notes:
+                n = Note(note.time + offset, note.pitch, note.vel, note.dur,
+                         note.id, **note.params)
+                self.notes.append(n)
+            self.notes.sort(key=lambda n: n.time)
+            end = max(self.time + self.dur,
+                      score_or_note.time + offset + score_or_note.dur)
+            self.dur = end - self.time
+        elif isinstance(score_or_note, Note):
+            n = Note(score_or_note.time + offset, score_or_note.pitch,
+                     score_or_note.vel, score_or_note.dur, score_or_note.id,
+                     **score_or_note.params)
+            self.notes.append(n)
+            self.dur = max(self.dur, n.time + n.dur)
+            self.notes.sort(key=lambda n: n.time)
+
+    def append(self, score_or_note):
+        offset = self.time + self.dur - (score_or_note.time if hasattr(
+            score_or_note, 'time') else 0)
+        self.merge(score_or_note, offset)
+
+    def stretch(self, factor):
+        for note in self.notes:
+            note.time *= factor
+            note.dur *= factor
+
+    def play(self, synth):
+        """Play all notes immediately (non-scheduled).
+
+        For real-time scheduled playback, integrate with your event loop.
+        """
+        import time as _time
+        if not self.notes:
+            return
+        prev_time = self.notes[0].time
+        for note in self.notes:
+            dt = note.time - prev_time
+            if dt > 0:
+                _time.sleep(dt)
+            note.play(synth)
+            prev_time = note.time
+
+
+# ======================== Synth (polyphonic manager) =========================
+
+_mix_name_counter = 0
+
+
+def mix_name(i):
+    """Generate a symbol-like string for mixer input naming."""
+    return f"in{i}"
+
+
+class Synth(Instrument):
+    """Polyphonic synthesizer: manages creation, reuse, and removal of notes.
+
+    Subclasses must override instr_create(note_spec, pitch, vel).
+    """
+
+    def __init__(self, instr_spec, customization, chans, param_names):
+        self.instr_spec = {}
+        self.param_names = list(param_names)
+        if 'chans' in self.param_names:
+            self.param_names.remove('chans')
+        self.notes = {}
+        self.free_notes = []
+        self.finishing_notes = []
+        self._prev_mixer_id = 0
+        self.has_retrigger = False
+
+        for p in self.param_names:
+            value = customization.get(p) if customization else None
+            if value is None:
+                value = instr_spec.get(p)
+            if value is not None:
+                self.instr_spec[p] = value
+
+        instr_begin()
+
+        instr_chans = instr_spec.get('chans')
+        chans = chans or instr_chans or 1
+        instr_chans = instr_chans or chans
+        self.instr_spec['chans'] = instr_chans
+
+        output = Mix(chans)
+        super().__init__("Synth", output)
+
+    def get_mixer_id(self):
+        self._prev_mixer_id += 1
+        return mix_name(self._prev_mixer_id)
+
+    def instr_create(self, note_spec, pitch, vel):
+        raise NotImplementedError("Subclasses must implement instr_create")
+
+    def noteon(self, pitch, vel, dur=None, id=None, pdict=None, **params):
+        if pdict and isinstance(pdict, dict):
+            pass  # use pdict as-is
+        elif params:
+            pdict = params
+        else:
+            pdict = pdict or {}
+
+        user_id = id if id is not None else round(pitch)
+
+        instr = self.notes.get(user_id)
+        if instr is not None:
+            if self.has_retrigger and hasattr(instr, 'retrigger'):
+                instr.retrigger(pitch, vel, dur, pdict)
+                return instr
+            self.noteoff(user_id)
+
+        if self.free_notes:
+            instr = self.free_notes.pop()
+            instr.user_id = user_id
+            for p in self.param_names:
+                value = pdict.get(p) or self.instr_spec.get(p)
+                pd = instr.parameter_bindings.get(p)
+                if value is not None and pd is not None and value != pd.value:
+                    instr.set(p, value, True)
+            instr.pitch = pitch
+            instr.vel = vel
+            if hasattr(instr, 'set_pitch_vel'):
+                instr.set_pitch_vel()
+        else:
+            note_spec = dict(self.instr_spec)
+            for p in self.param_names:
+                v = pdict.get(p)
+                if v is not None:
+                    note_spec[p] = v
+            instr = self.instr_create(note_spec, pitch, vel)
+            instr.pitch = pitch
+            instr.vel = vel
+
+        instr.user_id = user_id
+        gain_val = pdict.get('gain') or self.instr_spec.get('gain', 1)
+        self.notes[user_id] = instr
+
+        if self.chans > 1 and self.instr_spec.get('chans', 1) == 1:
+            pan = pdict.get('pan') or self.instr_spec.get('pan', 0.5)
+            gain_val = pan_45(pan / 127, gain_val)
+
+        gain_const = instr.gain
+        if gain_const is None:
+            gain_const = Const(gain_val, None)
+            instr.gain = gain_const
+
+        if isinstance(gain_val, list):
+            for i, g in enumerate(gain_val):
+                gain_const.set_chan(i, g)
+        else:
+            gain_const.set(gain_val)
+
+        self.output.ins(instr.mixer_id, instr, gain_const)
+        return instr
+
+    def noteoff(self, id):
+        if isinstance(id, float):
+            id = round(id)
+        if id not in self.notes:
+            print("WARNING: no note in Synth with id", id)
+            return
+        note = self.notes[id]
+        if hasattr(note, 'noteoff'):
+            note.noteoff()
+        del self.notes[id]
+        self.finishing_notes.append(note)
+
+    def is_finished(self, note):
+        if note in self.finishing_notes:
+            self.finishing_notes.remove(note)
+        elif note.user_id in self.notes:
+            del self.notes[note.user_id]
+        self.free_notes.append(note)
+
+    def update_note(self, id, param_name, value):
+        if param_name not in self.param_names:
+            print("Synth: param", param_name, "is not setable.")
+            return
+        if isinstance(id, float):
+            id = round(id)
+        instr = self.notes.get(id)
+        if instr is None:
+            print("WARNING: no note in Synth with id", id)
+            return
+        instr.set(param_name, value)
+
+    def update(self, param_name, value):
+        if param_name not in self.param_names:
+            print("Synth: param", param_name, "is not setable.")
+            return
+        self.instr_spec[param_name] = value
+        for instr in self.notes.values():
+            pd = instr.parameter_bindings.get(param_name)
+            if pd is not None:
+                pd.set(instr, value)
+
+
+# ======================== Reverb =============================================
+
+REVERB_COMBDELAY = [
+    0.028049887, 0.031315193, 0.036439909, 0.040294785, 0.044195011,
+    0.046780045
+]
+
+REVERB_ALLPASSDELAY = [
+    1 / hz for hz in
+    [143.6482085, 454.6391753, 621.1267606, 832.0754717, 1422.580645]
+]
+
+REVERB_DECAY = [0.822, 0.802, 0.773, 0.753, 0.753, 0.753]
+
+
+class Reverb(Instrument):
+    """Simple mono comb+allpass reverb (ported from Nyquist REVERB-MONO)."""
+
+    def __init__(self, input, rt60, wet=1, hz=10000, chans=None):
+        instr_begin()
+        self.combs = []
+        self.allpasses = []
+        rvb = Sum(1)
+        for i, delay_t in enumerate(REVERB_COMBDELAY):
+            fb = math.exp(-6.9087 * delay_t / (rt60 * REVERB_DECAY[i]))
+            c = Delay(input, delay_t, fb, delay_t + 0.001)
+            self.combs.append(c)
+            rvb.ins(c)
+
+        for i, delay_t in enumerate(REVERB_ALLPASSDELAY):
+            fb = math.exp(-6.9087 * delay_t / (rt60 * 0.7))
+            rvb_next = Allpass(rvb, delay_t, fb, delay_t + 0.001)
+            self.allpasses.append(rvb_next)
+            rvb = rvb_next
+
+        self._lowpass = Lowpass(rvb, min(hz, AR * 0.4))
+
+        if wet != 1:
+            output = Mix(1)
+            output.ins('dry', input, Const(1 - wet))
+            output.ins('wet', self._lowpass, Const(wet))
+        else:
+            output = self._lowpass
+
+        super().__init__("Reverb", output)
+
+    def set_input(self, input):
+        for cb in self.combs:
+            cb.set('input', input)
+
+    def set_rt60(self, rt60):
+        for i, cb in enumerate(self.combs):
+            fb = math.exp(-6.9087 * REVERB_COMBDELAY[i] /
+                          (rt60 * REVERB_DECAY[i]))
+            cb.set('fb', fb)
+        for i, ap in enumerate(self.allpasses):
+            fb = math.exp(-6.9087 * REVERB_ALLPASSDELAY[i] / (rt60 * 0.7))
+            ap.set('fb', fb)
+
+    def set_cutoff(self, freq):
+        self._lowpass.set('cutoff', freq)
+
+
+def reverb(input, rt60, wet=1, hz=10000):
+    """Create a mono Reverb instrument."""
+    return Reverb(input, rt60, wet, hz)
+
+
+class Multi_reverb(Instrument):
+    """Stereo (or multi-channel) reverb using one or two Reverb instances."""
+
+    def __init__(self, input, rt60, wet=1, hz=10000, chans=None):
+        chans = chans or input.chans
+        self.wet = wet
+        self._input = input
+        self.dry_input = None
+        self.reverbs = []
+        self.reverb_inputs = []
+        instr_begin()
+        self._multi_init(input, rt60, wet, hz, chans)
+        super().__init__("Multi_reverb", self.output)
+
+    def _multi_init(self, input, rt60, wet, hz, chans_):
+        left_route = Route(1)
+        self.reverb_inputs = [left_route]
+
+        if chans_ > 1:
+            right_route = Route(1)
+            self.reverb_inputs.append(right_route)
+
+        self._connect_input(input)
+
+        left_rev = Reverb(left_route, rt60, 1, hz)
+        self.reverbs = [left_rev]
+        right_rev = None
+        if chans_ > 1:
+            right_rev = Reverb(right_route, rt60 * 1.1, 1, hz * 1.1)
+            self.reverbs.append(right_rev)
+
+        self.output = Route(chans_)
+
+        if wet != 1:
+            left_wet = Math.mult(left_rev, wet)
+            if chans_ > 1:
+                right_wet = Math.mult(right_rev, wet)
+            self._connect_dry_inputs(input, chans_)
+            left_rev = left_wet
+            if chans_ > 1:
+                right_rev = right_wet
+
+        if chans_ > 1:
+            for i in range(chans_):
+                if i % 2 == 0:
+                    self.output.ins(left_rev, 0, i)
+                else:
+                    self.output.ins(right_rev, 0, i)
+        else:
+            self.output.ins(left_rev, 0, 0)
+
+    def _connect_input(self, new_input):
+        left_input = self.reverb_inputs[0]
+        if len(self.reverb_inputs) == 1:
+            for i in range(new_input.chans):
+                left_input.ins(new_input, i, 0)
+        else:
+            right_input = self.reverb_inputs[1]
+            for i in range(new_input.chans):
+                if i % 2 == 0:
+                    left_input.ins(new_input, i, 0)
+                else:
+                    right_input.ins(new_input, i, 0)
+            if new_input.chans == 1:
+                right_input.ins(new_input, 0, 0)
+
+        if self.reverbs:
+            self.reverbs[0].set_input(left_input)
+            if len(self.reverbs) > 1:
+                self.reverbs[1].set_input(right_input)
+
+    def _connect_dry_inputs(self, new_input, chans_):
+        dry_gain = 1 - self.wet
+        if self.dry_input is not None:
+            self.output.reminput(self.dry_input)
+        self.dry_input = Math.mult(new_input, dry_gain)
+        if new_input.chans == 1:
+            for i in range(chans_):
+                self.output.ins(self.dry_input, 0, i)
+        else:
+            for i in range(new_input.chans):
+                self.output.ins(self.dry_input, i, i % chans_)
+
+    def set_rt60(self, rt60):
+        for r in self.reverbs:
+            r.set_rt60(rt60)
+
+    def set_cutoff(self, freq):
+        for r in self.reverbs:
+            r.set_cutoff(freq)
+
+    def set_input(self, new_input):
+        self._connect_input(new_input)
+        if self.wet != 1:
+            self._connect_dry_inputs(new_input, self.output.chans)
+        self._input = new_input
+
+
+def multi_reverb(input, rt60, wet=1, hz=10000, chans=None):
+    """Create a multi-channel Reverb instrument."""
+    chans = chans or input.chans
+    return Multi_reverb(input, rt60, wet, hz, chans)
+
+
+# ======================== Supersaw ==========================================
+
+_sawtooth_waveforms = None
+
+
+class Sawtooth_waveforms:
+    """Singleton manager for anti-aliased sawtooth wavetables."""
+
+    def __init__(self):
+        global _sawtooth_waveforms
+        self.created = [None] * 36
+        self.tables = Tableosc(1, 1)
+        self.next_index = 0
+        _sawtooth_waveforms = self
+
+    def get_index(self, step, antialias=True):
+        if antialias:
+            i = max(min(int(step / 4), len(self.created) - 1), 1)
+        else:
+            i = 0
+        if self.created[i] is not None:
+            return self.created[i]
+        self.created[i] = self.next_index
+
+        if antialias:
+            f0 = step_to_hz(step)
+            n = max(1, int(AR * 2 / (5 * f0)))
+            tlen = max(16 * n, 512)
+            ampspec = [1 / (j + 1) for j in range(n)]
+            self.tables.create_tas(self.next_index, tlen, ampspec)
+        else:
+            ampspec = [i / 256 for i in range(256)]
+            self.tables.create_ttd(self.next_index, ampspec)
+
+        self.next_index += 1
+        return self.next_index - 1
+
+
+class Supersaw_instr(Instrument):
+    """A supersaw instrument with multiple detuned sawtooth oscillators."""
+
+    def __init__(self, synth, note_spec, pitch, vel):
+        global _sawtooth_waveforms
+        instr_begin()
+
+        if _sawtooth_waveforms is None:
+            Sawtooth_waveforms()
+
+        chans = note_spec.get('chans', 1)
+        self.n = max(1, round(note_spec.get('n', 8)))
+        self.rolloff = note_spec.get('rolloff', 0)
+        self.animate = note_spec.get('animate', 0)
+        self.decay_time = max(0, note_spec.get('decay', 0.1))
+        self.antialias = note_spec.get('antialias', 1)
+        rndphase = note_spec.get('rndphase', 1)
+        self.pitch = pitch
+        self.vel = vel
+        self.recalc_tableosc_amps = False
+
+        param_method('animate', self.animate, 'set_animate', 'clip', 0, 1)
+        self.animate_const = Const(self.animate)
+        param_method('antialias', self.antialias, 'set_antialias', 'clip', 0,
+                     1)
+        param_method('rolloff', self.rolloff, 'set_rolloff', 'clip', 0, 1)
+
+        table_index = _sawtooth_waveforms.get_index(pitch, self.antialias != 0)
+
+        if chans == 1:
+            self.mixer = Sum(1)
+        else:
+            width = note_spec.get('width', 0)
+            param_method('width', width, 'set_width', 'clip', 0, 1)
+            self.mixer = Stdistr(self.n, width)
+
+        attack = note_spec.get('attack', 0.04)
+        param_method('attack', attack, 'set_attack', 'clip', 0, None)
+        self.env = Pweb([attack, vel_to_linear(vel)])
+        self.env.linear_attack()
+
+        cutoff = note_spec.get('cutoff', 100)
+        param_method('cutoff', cutoff, 'set_cutoff')
+        lphz = min(AR * 0.4, step_to_hz(cutoff + pitch))
+        self._lowpass = Lowpass(self.mixer, lphz)
+        output = Math.mult(self._lowpass, self.env)
+
+        self.pitch_const = Const(pitch)
+        lfofreq = note_spec.get('lfofreq', 5)
+        lhz = param('lfofreq', lfofreq, 'map', 0, 20)
+        lfodepth = note_spec.get('lfodepth', 0)
+        ldp = param('lfodepth', lfodepth, 'map', 0, 2)
+        self.vib = Sineb(lhz, Mathb(MATH_OP_SUB, self.pitch_const, ldp))
+
+        self.shared_hz = Addb()
+        self.shared_hz.ins(Const(step_to_hz(pitch)))
+        self.shared_hz.ins(self.vib)
+
+        detune = note_spec.get('detune', 0)
+        dhz = param('detune', detune, 'map', 0, 2)
+        self.detune_hz = Mathb(MATH_OP_SUB, self.pitch_const, dhz)
+
+        anirate = note_spec.get('anirate', 1)
+        self.initial_detune = self.animate * steps_to_hzdiff(pitch, detune)
+        self.animate_detune = Mathb(MATH_OP_MUL, self.animate_const,
+                                    self.detune_hz)
+        self.anirate_const = param('anirate', anirate, 'map', 0, 10)
+
+        self._calc_gain_to_normalize()
+        self.components = [
+            self._supersaw_component(i, chans, table_index, rndphase)
+            for i in range(self.n)
+        ]
+
+        super().__init__("Supersaw", output, synth)
+
+    def _supersaw_component(self, i, chans, table_index, rndphase):
+        detune_frac = (i * 2) / (self.n - 1) - 1 if self.n > 1 else 0
+        fixed_fmod = Mathb(MATH_OP_MUL, self.detune_hz, Const(detune_frac))
+
+        hz = Addb()
+        hz.ins(self.shared_hz)
+        blend_ugen = Blendb(fixed_fmod, self.animate_detune,
+                            self.animate_const, BLEND_POWER)
+        hz.ins(blend_ugen)
+
+        amp = self._calc_tableosc_amp(i)
+        phase = rndphase * random.uniform(0, 360)
+        comp = Tableosc(hz, Const(amp), phase=phase)
+        comp.borrow(_sawtooth_waveforms.tables)
+        comp.select(table_index)
+
+        if chans == 1:
+            self.mixer.ins(comp)
+        else:
+            self.mixer.ins(i, comp)
+        return comp
+
+    def _calc_tableosc_amp(self, i):
+        k = abs(i - (self.n - 1) / 2)
+        return ((self.animate + (1 - self.animate) * (self.rolloff**k)) *
+                self.gain_to_normalize)
+
+    def _calc_gain_to_normalize(self):
+        rsqr = self.rolloff**2
+        power = 1
+        if self.rolloff == 1:
+            power += (self.n - 1)
+        elif self.n > 1:
+            power += 2 * rsqr * (1 - self.rolloff**
+                                 (self.n - 1)) / (1 - rsqr) if rsqr != 1 else 0
+        power = self.n * self.animate + power * (1 - self.animate)
+        self.gain_to_normalize = 1 / math.sqrt(max(power, 0.001))
+
+    def _calc_tableosc_amps(self):
+        self._calc_gain_to_normalize()
+        for i, comp in enumerate(self.components):
+            amp = self._calc_tableosc_amp(i)
+            comp.set('amp', amp)
+
+    def set_rolloff(self, rolloff_, reuse=False):
+        self.rolloff = rolloff_
+        if reuse:
+            self.recalc_tableosc_amps = True
+        else:
+            self._calc_tableosc_amps()
+
+    def set_attack(self, attack_, reuse=False):
+        self.attack = attack_
+
+    def set_animate(self, animate_, reuse=False):
+        self.animate = animate_
+        self.animate_const.set(animate_)
+        if reuse:
+            self.recalc_tableosc_amps = True
+        else:
+            self._calc_tableosc_amps()
+
+    def set_cutoff(self, cutoff, reuse=False):
+        self._lowpass.set('cutoff',
+                          min(AR * 0.4, step_to_hz(cutoff + self.pitch)))
+
+    def set_antialias(self, antialias_, reuse=False):
+        self.antialias = antialias_
+        if not reuse:
+            self._calc_tableosc_index()
+
+    def set_width(self, width, reuse=False):
+        if self.chans == 2:
+            self.mixer.set_width(width)
+
+    def _calc_tableosc_index(self):
+        table_index = _sawtooth_waveforms.get_index(self.pitch, self.antialias
+                                                    != 0)
+        for comp in self.components:
+            comp.select(table_index)
+
+    def set_pitch_vel(self):
+        if self.recalc_tableosc_amps:
+            self._calc_tableosc_amps()
+            self.recalc_tableosc_amps = False
+        self.pitch_const.set(self.pitch)
+        self.shared_hz.set('x1', step_to_hz(self.pitch))
+        self._calc_tableosc_index()
+        self.env.set_points(self.attack if hasattr(self, 'attack') else 0.04,
+                            vel_to_linear(self.vel))
+        self.env.start()
+
+    def noteoff(self):
+        self.env.decay(self.decay_time)
+
+
+class Supersaw_synth(Synth):
+    """A Synth that creates Supersaw_instr instances."""
+
+    def __init__(self, instr_spec, customization=None, chans=None):
+        super().__init__(instr_spec, customization or {}, chans, [
+            'animate', 'anirate', 'antialias', 'n', 'rndphase', 'detune',
+            'width', 'rolloff', 'attack', 'decay', 'cutoff', 'lfofreq',
+            'lfodepth'
+        ])
+
+    def instr_create(self, note_spec, pitch, vel):
+        return Supersaw_instr(self, note_spec, pitch, vel)

--- a/pyarco/arco_ugens.py
+++ b/pyarco/arco_ugens.py
@@ -1,0 +1,1573 @@
+import threading
+
+from arco_engine import (
+    get_engine,
+    A_RATE, B_RATE, C_RATE, NO_RATE,
+    ZERO_ID, ZEROB_ID, INPUT_ID, OUTPUT_ID,
+    AR, BL, BR, BP,
+    FADE_LINEAR, FADE_SMOOTH, FADE_EXPONENTIAL, FADE_LOWPASS,
+    BLEND_LINEAR, BLEND_POWER, BLEND_45,
+    MATH_OP_MUL, MATH_OP_ADD, MATH_OP_SUB, MATH_OP_DIV,
+    MATH_OP_MAX, MATH_OP_MIN, MATH_OP_CLP, MATH_OP_POW,
+    MATH_OP_LT, MATH_OP_GT, MATH_OP_SCP, MATH_OP_PWI,
+    MATH_OP_RND, MATH_OP_SH, MATH_OP_QNT, MATH_OP_RLI,
+    MATH_OP_HZDIFF, MATH_OP_TAN, MATH_OP_ATAN2, MATH_OP_SIN, MATH_OP_COS,
+    UNARY_OP_ABS, UNARY_OP_NEG, UNARY_OP_EXP, UNARY_OP_LOG,
+    UNARY_OP_LOG10, UNARY_OP_LOG2, UNARY_OP_SQRT,
+    UNARY_OP_STEP_TO_HZ, UNARY_OP_HZ_TO_STEP,
+    UNARY_OP_VEL_TO_LINEAR, UNARY_OP_LINEAR_TO_VEL,
+    UNARY_OP_DB_TO_LINEAR, UNARY_OP_LINEAR_TO_DB,
+    DNSAMPLE_BASIC, DNSAMPLE_AVG, DNSAMPLE_PEAK, DNSAMPLE_RMS,
+    DNSAMPLE_POWER, DNSAMPLE_LOWPASS500, DNSAMPLE_LOWPASS100,
+    ACTION_END_OR_TERM, ACTION_FREE, MUTE, FINISH,
+    max_chans,
+)
+
+
+class Ugen:
+
+    def __init__(
+        self,
+        classname_,
+        chans_,
+        rate_,
+        types_,
+        no_msg=None,
+        omit_chans=None,
+        *inputs_,
+        engine=None,
+        id_num=None,
+    ):
+        self.engine = engine or get_engine()
+
+        inputs_ = list(inputs_)
+        if id_num is not None:
+            self.id = id_num
+        else:
+            self.id = self.engine.id_pool.request_slot()
+        self.engine.register(self)
+        self.classname = classname_
+        self.chans = chans_
+        self.rate = rate_
+        self.inputs = {}
+        self.action_id = None
+
+        if no_msg:
+            return
+
+        # Convert numbers to const()
+        for i in range(1, len(inputs_), 2):
+            if types_[i // 2] == "U" and (isinstance(inputs_[i], (int, float))
+                                          or isinstance(inputs_[i], list)):
+                inputs_[i] = Const(inputs_[i], None)
+
+        # construct the message
+        address = f"/arco/{self.classname.lower()}/new"
+        params = []
+        type_str = "i"  # only the id at first
+
+        params.append(self.id)
+
+        if not omit_chans:  # some Ugens do not have chans parameter
+            params.append(self.chans)
+            type_str += "i"
+
+        for i in range(0, len(inputs_), 2):
+            inp = inputs_[i + 1]  # the value
+            if types_[i // 2] == "U":
+                params.append(inp.id)
+                self.inputs[
+                    inputs_[i]] = inp  # put the kv pair in the inputs dict
+                type_str += "i"
+            else:  # one of "sihdft"
+                params.append(inp)
+                type_str += types_[i // 2]
+
+        self.engine.send_cmd(address, 0, type_str, *params)
+
+    def __del__(self):
+        if getattr(self, 'engine', None) is not None:
+            self.engine.send_cmd("/arco/free", 0, "i", self.id)
+            if self.id >= self.engine.id_pool.start_id:
+                self.engine.id_pool.free_slot(self.id)
+            self.engine.unregister(self.id)
+
+    def play(self):
+        self.engine.send_cmd("/arco/sum/ins", 0, "ii", OUTPUT_ID, self.id)
+
+    def mute(self, status=None):
+        # status is accepted (passed by atend actions) but ignored here
+        self.engine.send_cmd("/arco/sum/rem", 0, "ii", OUTPUT_ID, self.id)
+
+    def fade(self, dur, mode=FADE_SMOOTH):
+        """Fade output to zero over dur seconds, then disconnect."""
+        fader = self.engine.fade_in_lookup.get(self.id)
+        if fader:
+            # fade_in is in progress; convert to fade out
+            del self.engine.fade_in_lookup[self.id]
+            fader.set_dur(dur)
+            fader.set_goal(0)
+            fader.set_mode(mode)
+            return fader
+        else:
+            faded = create_fader(self, 1, dur, 0)
+            faded.term()
+            # swap self out of output, put faded in
+            self.engine.send_cmd("/arco/sum/swap", 0, "iii", OUTPUT_ID,
+                            self.id, faded.id)
+            faded.set_mode(mode)
+            return faded
+
+    def fade_in(self, dur, mode=FADE_SMOOTH, term=True):
+        """Fade in from silence. Ugen must NOT already be playing."""
+        fader = create_fader(self, 0, dur, 1)
+        if term:
+            fader.term()
+        self.engine.fade_in_lookup[self.id] = fader
+        fader.set_mode(mode)
+        fader.play()
+
+        def _fade_in_complete():
+            if self.engine is not None:
+                f = self.engine.fade_in_lookup.get(self.id)
+                if f is not None:
+                    # swap fader out, put the original ugen directly in output
+                    self.engine.send_cmd("/arco/sum/swap", 0, "iii", OUTPUT_ID,
+                                    f.id, self.id)
+                    del self.engine.fade_in_lookup[self.id]
+
+        threading.Timer(dur + 0.1, _fade_in_complete).start()
+
+    def run(self):  # add this Ugen to the run set
+        self.engine.send_cmd("/arco/run", 0, "i", self.id)
+
+    def unrun(self):  # remove this Ugen from the run set
+        self.engine.send_cmd("/arco/unrun", 0, "i", self.id)
+
+    def get(self, input_name):
+        return self.inputs[input_name]
+
+    def set(self, input_name, value, chan=0):
+        previous = self.inputs.get(input_name)
+        if previous is None:
+            if not isinstance(input_name, str):
+                print("ERROR: set() called with input " + str(input_name) +
+                      " of type '" + type(input_name).__name__ + "'")
+            else:
+                print("ERROR: " + str(input_name) + " not found in '" +
+                      self.classname + "'")
+            return
+
+        addr_prefix = "/arco/" + self.classname.lower()
+
+        if isinstance(value, list):
+            # Array of numbers: update multiple channels of a Const input.
+            # If current input is not Const, replace it with a new Const.
+            if previous.rate != C_RATE:
+                value = Const(value, None)
+                self.inputs[input_name] = value
+                self.engine.send_cmd(addr_prefix + "/repl_" + str(input_name),
+                                0, "ii", self.id, value.id)
+            else:
+                for i, v in enumerate(value):
+                    if i < previous.chans:
+                        self.engine.send_cmd(addr_prefix + "/set_" +
+                                        str(input_name),
+                                        0, "iif", self.id, i, v)
+            return
+
+        if isinstance(value, (int, float)):
+            if previous.rate == C_RATE:
+                if chan >= previous.chans:
+                    print("ERROR: const '" + str(input_name) + "' of '" +
+                          self.classname + "' has " + str(previous.chans) +
+                          " channels but attempt to set channel " + str(chan))
+                    return
+                self.engine.send_cmd(addr_prefix + "/set_" + str(input_name),
+                                0, "iif", self.id, chan, value)
+                return
+            value = Const(value, None)
+
+        # value is a Ugen: replace the input
+        self.inputs[input_name] = value
+        self.engine.send_cmd(addr_prefix + "/repl_" + str(input_name),
+                        0, "ii", self.id, value.id)
+
+    def atend(self, action, target=None, mask=ACTION_END_OR_TERM):
+        """Register an action (MUTE or FINISH) when this ugen ends."""
+        if action == MUTE or action == FINISH:
+            self.engine.register_action(self, mask, target or self, action)
+        else:
+            print("ERROR: Ugen.atend - unknown action", repr(action))
+
+    def term(self, dur=0):
+        """Enable termination; after ugen ends, terminate after dur seconds."""
+        self.engine.send_cmd("/arco/term", 0, "if", self.id, dur)
+        return self
+
+    def trace(self, trace_flag=True):
+        """Set UGENTRACE flag for debugging."""
+        self.engine.send_cmd("/arco/trace", 0, "ii", self.id,
+                        1 if trace_flag else 0)
+        return self
+
+
+def create_fader(input, current, dur=None, goal=None, chans=None):
+    """Helper to create a Fader with optional dur/goal initialization."""
+    f = Fader(input, current, chans=chans)
+    if dur is not None:
+        f.set_dur(dur)
+    if goal is not None:
+        f.set_goal(goal)
+    return f
+
+
+# An abstract class for Const and Smoothb
+class Const_like(Ugen):
+
+    def send_floats(self, values, msg):
+        x = []
+
+        # Send a message with address msg by adding float values
+        for i in range(self.chans):
+            if isinstance(values, (int, float)):
+                f = values  # same value for all chans
+            else:  # values is a list
+                f = values[i] if len(values) > i else 0
+            x.append(f)
+
+        self.engine.send_cmd(msg, 0, "i" + "f" * self.chans, self.id, *x)
+
+
+class Const(Const_like):
+
+    def __init__(self, values, chans=None):
+        # values is initial value or array of initial values
+        # chans is length of values (chans_default) unless specified by the parameter
+        chans_default = max(len(values), 1) if isinstance(values, list) else 1
+        self.chans = chans if chans else chans_default
+        super().__init__(
+            "Const", self.chans, C_RATE, "", True, None
+        )  # no_msg=True to issue a special message and ignore the inputs
+        self.send_floats(values, "/arco/const/newn")
+
+    def set(self, values):
+        # overload the set method of Ugen
+        self.send_floats(values, "/arco/const/setn")
+        return self
+
+    def set_chan(self, chan, value):
+        # Set the value of a specific channel
+        self.engine.send_cmd("/arco/const/set", 0, "iif", self.id, chan, value)
+        return self
+
+
+class Sine(Ugen):
+
+    def __init__(self, freq, amp, chans=None):
+        if chans is None:
+            chans = max_chans(max_chans(1, freq), amp)
+        super().__init__("Sine", chans, A_RATE, "UU", None, None, "freq", freq,
+                         "amp", amp)
+
+
+class Sineb(Ugen):
+
+    def __init__(self, freq, amp, chans=None):
+        if not isinstance(freq, (int, float)) and freq.rate != B_RATE:
+            print("ERROR: 'freq' input to Ugen 'sineb' must be block rate")
+            return
+        if not isinstance(amp, (int, float)) and amp.rate != B_RATE:
+            print("ERROR: 'amp' input to Ugen 'sineb' must be block rate")
+            return
+
+        if chans is None:
+            chans = max_chans(max_chans(1, freq), amp)
+
+        super().__init__("Sineb", chans, B_RATE, "UU", None, None, "freq",
+                         freq, "amp", amp)
+
+
+class Fader(Ugen):
+
+    def __init__(self, input, current, mode=FADE_SMOOTH, chans=None):
+        if chans is None:
+            chans = max_chans(1, input)
+        super().__init__("Fader", chans, A_RATE, "Ufi", None, None, 'input',
+                         input, 'current', current, 'mode', mode)
+
+    def set_current(self, current, chan=None):
+        if chan is not None:
+            self.engine.send_cmd("/arco/fader/cur", 0, "iif", self.id, chan,
+                            current)
+        else:
+            for i in range(self.chans):
+                self.engine.send_cmd(
+                    "/arco/fader/cur", 0, "iif", self.id, i,
+                    current if isinstance(current,
+                                          (int, float)) else current[i])
+        return self
+
+    def set_dur(self, dur):
+        self.engine.send_cmd("/arco/fader/dur", 0, "if", self.id, dur)
+        return self
+
+    def set_mode(self, mode):
+        self.engine.send_cmd("/arco/fader/mode", 0, "ii", self.id, mode)
+        return self
+
+    def set_goal(self, goal, chan=None):
+        if chan is not None:
+            self.engine.send_cmd("/arco/fader/goal", 0, "iif", self.id, chan, goal)
+        else:
+            for i in range(self.chans):
+                self.engine.send_cmd(
+                    "/arco/fader/goal", 0, "iif", self.id, i,
+                    goal if isinstance(goal, (int, float)) else goal[i])
+        return self
+
+
+class Smoothb(Const_like):
+
+    def __init__(self, x, cutoff=10, chans=None):
+        chans_default = max(len(x), 1) if isinstance(x, list) else 1
+        self.chans = chans if chans else chans_default
+
+        super().__init__("Smoothb", self.chans, B_RATE, "", True, None)
+
+        self.send_floats([cutoff] +
+                         (x if isinstance(x, list) else [x] * self.chans),
+                         "/arco/smoothb/newn")
+
+    def set(self, x):
+        self.send_floats(x, "/arco/smoothb/setn")
+        return self
+
+    def set_chan(self, chan, x):
+        self.engine.send_cmd("/arco/smoothb/set", 0, "iif", self.id, chan, x)
+        return self
+
+    def set_cutoff(self, cutoff):
+        self.engine.send_cmd("/arco/smoothb/cutoff", 0, "if", self.id, cutoff)
+        return self
+
+
+class Delay(Ugen):
+
+    def __init__(self, input, dur, fb, maxdur, chans=None):
+        if chans is None:
+            chans = max_chans(1, input)
+        super().__init__("Delay", chans, A_RATE, "UUUf", None, None, 'input',
+                         input, 'dur', dur, 'fb', fb, 'maxdur', maxdur)
+
+
+class Feedback(Ugen):
+
+    def __init__(self, input, from_ugen, gain, chans=1):
+        if chans is None:
+            chans = max_chans(max_chans(max_chans(1, input), from_ugen), gain)
+        super().__init__("Feedback", chans, A_RATE, "UUU", None, None, 'input',
+                         input, 'from', from_ugen, 'gain', gain)
+
+
+class Reson(Ugen):
+
+    def __init__(self, snd, center, q, chans=None):
+        if not isinstance(snd, (int, float)) and snd.rate != A_RATE:
+            print("ERROR: 'snd' input to Ugen 'reson' must be audio rate")
+            return None
+        if chans is None:
+            chans = max_chans(max_chans(max_chans(1, snd), center), q)
+        super().__init__("Reson", chans, A_RATE, "UUU", None, None, 'snd', snd,
+                         'center', center, 'q', q)
+
+
+class Resonb(Ugen):
+
+    def __init__(self, snd, center, q, chans=None):
+        if not isinstance(snd, (int, float)) and snd.rate != B_RATE:
+            print("ERROR: 'snd' input to Ugen 'resonb' must be block rate")
+            return None
+        if not isinstance(center, (int, float)) and center.rate != B_RATE:
+            print("ERROR: 'center' input to Ugen 'resonb' must be block rate")
+            return None
+        if not isinstance(q, (int, float)) and q.rate != B_RATE:
+            print("ERROR: 'q' input to Ugen 'resonb' must be block rate")
+            return None
+        if chans is None:
+            chans = max_chans(max_chans(max_chans(1, snd), center), q)
+        super().__init__("Resonb", chans, B_RATE, "UUU", None, None, 'snd',
+                         snd, 'center', center, 'q', q)
+
+
+class Lowpass(Ugen):
+
+    def __init__(self, snd, cutoff, chans=None):
+        if not isinstance(snd, (int, float)) and snd.rate != A_RATE:
+            print("ERROR: 'snd' input to Ugen 'lowpass' must be audio rate")
+            return None
+        if chans is None:
+            chans = max_chans(max_chans(1, snd), cutoff)
+        super().__init__("Lowpass", chans, A_RATE, "UU", None, None, 'snd',
+                         snd, 'cutoff', cutoff)
+
+
+class Allpass(Ugen):
+
+    def __init__(self, input, dur, fb, maxdur, chans=None):
+        if chans is None:
+            chans = max_chans(1, input)
+        super().__init__("Allpass", chans, A_RATE, "UUUf", None, None, 'input',
+                         input, 'dur', dur, 'fb', fb, 'maxdur', maxdur)
+
+
+class Blend(Ugen):
+
+    def __init__(self, x1, x2, b, mode=BLEND_LINEAR, init_b=0.5, chans=None,
+                 gain=1):
+        if chans is None:
+            chans = max_chans(max_chans(max_chans(1, x1), x2), b)
+        super().__init__("Blend", chans, A_RATE, "UUUfi", None, None, 'x1', x1,
+                         'x2', x2, 'b', b, 'init_b', init_b, 'mode', mode)
+        if gain != 1:
+            self.set_gain(gain)
+
+    def set_gain(self, gain):
+        self.engine.send_cmd("/arco/blend/gain", 0, "if", self.id, gain)
+        return self
+
+    def set_mode(self, mode):
+        self.engine.send_cmd("/arco/blend/mode", 0, "ii", self.id, mode)
+        return self
+
+
+class Blendb(Ugen):
+
+    def __init__(self, x1, x2, b, mode=BLEND_LINEAR, chans=None, gain=1):
+        if chans is None:
+            chans = max_chans(max_chans(max_chans(1, x1), x2), b)
+        super().__init__("Blendb", chans, B_RATE, "UUUi", None, None, 'x1', x1,
+                         'x2', x2, 'b', b, 'mode', mode)
+        if gain != 1:
+            self.set_gain(gain)
+
+    def set_gain(self, gain):
+        self.engine.send_cmd("/arco/blendb/gain", 0, "if", self.id, gain)
+        return self
+
+    def set_mode(self, mode):
+        self.engine.send_cmd("/arco/blendb/mode", 0, "ii", self.id, mode)
+        return self
+
+
+class Fileplay(Ugen):
+
+    def __init__(self,
+                 filename,
+                 chans=2,
+                 start=0,
+                 end=0,
+                 cycle=False,
+                 mix=False,
+                 expand=False):
+        super().__init__("Fileplay", chans, A_RATE, "sffBBB", None, None,
+                         'filename', filename, 'start', start, 'end', end,
+                         'cycle', cycle, 'mix', mix, 'expand', expand)
+
+    def go(self, play_flag=True):
+        self.engine.send_cmd("/arco/fileplay/play", 0, "iB", self.id, play_flag)
+        return self
+
+    def stop(self):
+        return self.go(False)
+
+
+class Filerec(Ugen):
+
+    def __init__(self, filename, input, chans=2):
+        super().__init__("Filerec", chans, '', "sU", None, None, 'filename',
+                         filename, 'input', input)
+
+    def go(self, rec_flag=True):
+        self.engine.send_cmd("/arco/filerec/rec", 0, "iB", self.id, rec_flag)
+        return self
+
+    def stop(self):
+        return self.go(False)
+
+
+class Recplay(Ugen):
+
+    def __init__(self, input, chans=1, gain=1, fade_time=0.1, loop=False):
+        super().__init__("Recplay", chans, A_RATE, "UUfB", None, None, 'input',
+                         input, 'gain', gain, 'fade_time', fade_time, 'loop',
+                         loop)
+
+    def record(self, record_flag):
+        self.engine.send_cmd("/arco/recplay/rec", 0, "iB", self.id, record_flag)
+        return self
+
+    def start(self, start_time):
+        self.engine.send_cmd("/arco/recplay/start", 0, "id", self.id, start_time)
+        return self
+
+    def stop(self):
+        self.engine.send_cmd("/arco/recplay/stop", 0, "i", self.id)
+        return self
+
+    def set_speed(self, x):
+        self.engine.send_cmd("/arco/recplay/speed", 0, "if", self.id, x)
+        return self
+
+    def borrow(self, u):
+        self.engine.send_cmd("/arco/recplay/borrow", 0, "ii", self.id, u.id)
+        return self
+
+
+class Sum(Ugen):
+
+    def __init__(self, chans, wrap=True, id_num=None):
+        super().__init__("Sum", chans, A_RATE, "i", None, None, 'wrap',
+                         1 if wrap else 0, id_num=id_num)
+
+    def ins(self, *ugens):
+        for ugen in ugens:
+            self.engine.send_cmd("/arco/sum/ins", 0, "ii", self.id, ugen.id)
+        return self
+
+    def rem(self, *ugens):
+        for ugen in ugens:
+            self.engine.send_cmd("/arco/sum/rem", 0, "ii", self.id, ugen.id)
+        return self
+
+    def swap(self, ugen, replacement):
+        self.engine.send_cmd("/arco/sum/swap", 0, "iii", self.id, ugen.id,
+                        replacement.id)
+        return self
+
+    def set_gain(self, gain):
+        self.engine.send_cmd("/arco/sum/set_gain", 0, "if", self.id, gain)
+        return self
+
+
+class Sumb(Ugen):
+
+    def __init__(self, chans, wrap=True, id_num=None):
+        super().__init__("Sumb", chans, B_RATE, "i", None, None, 'wrap',
+                         1 if wrap else 0, id_num=id_num)
+
+    def ins(self, *ugens):
+        for ugen in ugens:
+            self.engine.send_cmd("/arco/sumb/ins", 0, "ii", self.id, ugen.id)
+        return self
+
+    def rem(self, *ugens):
+        for ugen in ugens:
+            self.engine.send_cmd("/arco/sumb/rem", 0, "ii", self.id, ugen.id)
+        return self
+
+    def swap(self, ugen, replacement):
+        self.engine.send_cmd("/arco/sumb/swap", 0, "iii", self.id, ugen.id,
+                        replacement.id)
+        return self
+
+    def set_gain(self, gain):
+        self.engine.send_cmd("/arco/sumb/set_gain", 0, "if", self.id, gain)
+        return self
+
+
+class Route(Ugen):
+
+    def __init__(self, chans):
+        super().__init__("Route", chans, A_RATE, "", None, None)
+
+    def ins(self, input, *routes):
+        self._send_ins_rem(input, routes, "/arco/route/ins")
+        return self
+
+    def rem(self, input, *routes):
+        self._send_ins_rem(input, routes, "/arco/route/rem")
+        return self
+
+    def reminput(self, input):
+        self.engine.send_cmd("/arco/route/reminput", 0, "ii", self.id, input.id)
+        return self
+
+    def _send_ins_rem(self, input, routes, address):
+        params = [self.id, input.id]
+        params.extend(routes)
+        type_str = "i" * (len(params))
+
+        self.engine.send_cmd(address, 0, type_str, *params)
+
+
+class Vu(Ugen):
+
+    def __init__(self, reply_addr, period):
+        super().__init__("Vu", 0, '', "sf", None, None, 'reply_addr',
+                         reply_addr, 'period', period)
+
+    def start(self, reply_addr, period):
+        self.engine.send_cmd("/arco/vu/start", 0, "isf", self.id, reply_addr,
+                        period)
+        return self
+
+    def set(self, input_name, value):
+        self.inputs['input'] = value
+        self.engine.send_cmd("/arco/vu/repl_input", 0, "ii", self.id, value.id)
+        return self
+
+
+class Trig(Ugen):
+
+    def __init__(self, input, reply_addr, window, threshold, pause):
+        super().__init__("Trig", 0, A_RATE, "Usiff", None, True, 'input',
+                         input, 'reply_addr', reply_addr, 'window', window,
+                         'threshold', threshold, 'pause', pause)
+
+    def set_window(self, window):
+        self.engine.send_cmd("/arco/trig/window", 0, "ii", self.id, window)
+        return self
+
+    def set_threshold(self, threshold):
+        self.engine.send_cmd("/arco/trig/threshold", 0, "if", self.id, threshold)
+        return self
+
+    def set_pause(self, pause):
+        self.engine.send_cmd("/arco/trig/pause", 0, "if", self.id, pause)
+        return self
+
+    def onoff(self, reply_addr, threshold, runlen):
+        self.engine.send_cmd("/arco/trig/onoff", 0, "isff", self.id, reply_addr,
+                        threshold, runlen)
+        return self
+
+
+class Thru(Ugen):
+
+    def __init__(self, input, chans=1, id_num=None):
+        super().__init__("Thru", chans, A_RATE, "U", None, None, 'input',
+                         input, id_num=id_num)
+
+    def set_alternate(self, alt):
+        self.engine.send_cmd("/arco/thru/alt", 0, "ii", self.id, alt.id)
+        return self
+
+
+class Fanout(Thru):
+
+    def __init__(self, input, chans):
+        super().__init__(input, chans)
+
+
+class Dnsampleb(Ugen):
+
+    def __init__(self, input, mode, chans=1):
+        super().__init__("Dnsampleb", chans, B_RATE, "Ui", None, None, 'input',
+                         input, 'mode', mode)
+
+    def set_cutoff(self, hz):
+        self.engine.send_cmd("/arco/dnsampleb/cutoff", 0, "if", self.id, hz)
+        return self
+
+    def set_mode(self, mode):  # refer to the constants, like 'DNSAMPLE_BASIC'
+        self.engine.send_cmd("/arco/dnsampleb/mode", 0, "ii", self.id, mode)
+        return self
+
+
+class Dualslewb(Ugen):
+
+    def __init__(self,
+                 input,
+                 chans=1,
+                 attack=0.02,
+                 release=0.02,
+                 current=0,
+                 attack_linear=True,
+                 release_linear=True):
+        super().__init__("Dualslewb", chans, B_RATE, "Ufffii", None, None,
+                         'input', input, 'attack', attack, 'release', release,
+                         'current', current, 'attack_linear',
+                         1 if attack_linear else 0, 'release_linear',
+                         1 if release_linear else 0)
+
+    def set_current(self, current):
+        self.engine.send_cmd("/arco/dualslewb/current", 0, "if", self.id, current)
+        return self
+
+    def set_attack(self, attack, attack_linear=True):
+        self.engine.send_cmd("/arco/dualslewb/attack", 0, "ifi", self.id, attack,
+                        1 if attack_linear else 0)
+        return self
+
+    def set_release(self, release, release_linear=True):
+        self.engine.send_cmd("/arco/dualslewb/release", 0, "ifi", self.id, release,
+                        1 if release_linear else 0)
+        return self
+
+
+class Probe(Ugen):
+
+    def __init__(self, input, reply_addr):
+        self.running = False
+        super().__init__("Probe", 0, NO_RATE, "Us", None, True, 'input', input,
+                         'reply_addr', reply_addr)
+
+    def probe(self, period, frames, chan, nchans, stride, repeats=0):
+        self.engine.send_cmd("/arco/probe/probe", 0, "ifiiiii", self.id, period,
+                        frames, chan, nchans, stride, repeats)
+        if not self.running:
+            self.run()  # suppress warning if we're already in run set
+            self.running = True
+        return self
+
+    def thresh(self, threshold, direction, max_wait):
+        self.engine.send_cmd("/arco/probe/thresh", 0, "ifif", self.id, threshold,
+                        direction, max_wait)
+        return self
+
+    def stop(self):
+        self.engine.send_cmd("/arco/probe/stop", 0, "i", self.id)
+        if self.running:
+            self.unrun()
+            self.running = False
+        return self
+
+
+class Envelope(Ugen):
+
+    def __init__(self,
+                 classname,
+                 addr,
+                 rate,
+                 points,
+                 init=None,
+                 start=False,
+                 lin=None):
+        self.address = addr
+        super().__init__(classname, 1, rate, "", None, True)
+        self.sample_rate = AR if rate == A_RATE else BR
+        self.set_point_array(points)
+
+        if init is not None:
+            self.set(init)
+        if start:
+            self.start()
+        if lin is not None:
+            self.linear_attack(lin)
+
+    def set_point_array(self, points):
+        params = [self.id]
+        time = 0
+        count = 0
+
+        for i in range(0, len(points), 2):
+            time += points[i]
+            samples = max(1, round(time * self.sample_rate - count))
+            count += samples
+            params.append(float(samples))
+
+            if i + 1 < len(
+                    points):  # if length is odd, append a zero amplitude
+                params.append(float(points[i + 1]))
+
+        type_str = "i" + "f" * (len(params) - 1)
+        self.engine.send_cmd(f"{self.address}env", 0, type_str, *params)
+        return self
+
+    def set_points(self, *points):
+        self.set_point_array(points)
+        return self
+
+    def start(self):
+        self.engine.send_cmd(f"{self.address}start", 0, "i", self.id)
+        return self
+
+    def stop(self):
+        self.engine.send_cmd(f"{self.address}stop", 0, "i", self.id)
+        return self
+
+    def decay(self, dur):
+        self.engine.send_cmd(f"{self.address}decay", 0, "if", self.id,
+                        dur * self.sample_rate)
+        return self
+
+    def linear_attack(self, lin=True):
+        self.engine.send_cmd(f"{self.address}linatk", 0, "iB", self.id, lin)
+        return self
+
+    def set(self, y):
+        self.engine.send_cmd(f"{self.address}set", 0, "if", self.id, y)
+        return self
+
+
+class Pwl(Envelope):
+
+    def __init__(self, points, initial_value=None, start=True):
+        super().__init__("Pwl", "/arco/pwl/", A_RATE, points, initial_value,
+                         start)
+
+
+class Pwlb(Envelope):
+
+    def __init__(self, points, initial_value=None, start=True):
+        super().__init__("Pwlb", "/arco/pwlb/", B_RATE, points, initial_value,
+                         start)
+
+
+class Pwe(Envelope):
+
+    def __init__(self, points, initial_value=None, start=True, lin=None):
+        super().__init__("Pwe", "/arco/pwe/", A_RATE, points, initial_value,
+                         start, lin)
+
+
+class Pweb(Envelope):
+
+    def __init__(self, points, initial_value=None, start=True, lin=None):
+        super().__init__("Pweb", "/arco/pweb/", B_RATE, points, initial_value,
+                         start, lin)
+
+
+class Pv(Ugen):
+
+    def __init__(self, input, ratio, fftsize, hopsize, points, mode, chans=1):
+        super().__init__("Pv", chans, A_RATE, "Ufiiii", None, None, 'input',
+                         input, 'ratio', ratio, 'fftsize', fftsize, 'hopsize',
+                         hopsize, 'points', points, 'mode', mode)
+
+    def set_ratio(self, value):
+        self.engine.send_cmd("/arco/pv/ratio", 0, "if", self.id, value)
+        return self
+
+    def set_stretch(self, value):
+        self.engine.send_cmd("/arco/pv/stretch", 0, "if", self.id, value)
+        return self
+
+
+class Granstream(Ugen):
+
+    def __init__(self, input, polyphony, dur, enable, chans=1):
+        super().__init__("Granstream", chans, A_RATE, "UifB", None, None,
+                         'input', input, 'polyphony', polyphony, 'dur', dur,
+                         'enable', enable)
+
+    def set_gain(self, gain):
+        self.engine.send_cmd("/arco/granstream/gain", 0, "if", self.id, gain)
+        return self
+
+    def set_polyphony(self, p):
+        self.engine.send_cmd("/arco/granstream/polyphony", 0, "if", self.id, p)
+        return self
+
+    def set_ratio(self, low, high):
+        self.engine.send_cmd("/arco/granstream/ratio", 0, "iff", self.id, low, high)
+        return self
+
+    def set_graindur(self, lowdur, highdur):
+        self.engine.send_cmd("/arco/granstream/graindur", 0, "iff", self.id, lowdur,
+                        highdur)
+        return self
+
+    def set_density(self, density):
+        self.engine.send_cmd("/arco/granstream/density", 0, "if", self.id, density)
+        return self
+
+    def set_env(self, attack, release):
+        self.engine.send_cmd("/arco/granstream/env", 0, "iff", self.id, attack,
+                        release)
+        return self
+
+    def set_enable(self, enable):
+        self.engine.send_cmd("/arco/granstream/enable", 0, "iB", self.id, enable)
+        return self
+
+    def set_dur(self, dur):
+        self.engine.send_cmd("/arco/granstream/dur", 0, "if", self.id, dur)
+        return self
+
+    def set_delay(self, d):
+        self.engine.send_cmd("/arco/granstream/delay", 0, "if", self.id, d)
+        return self
+
+    def set_feedback(self, fb):
+        self.engine.send_cmd("/arco/granstream/feedback", 0, "if", self.id, fb)
+        return self
+
+
+class Math(Ugen):
+
+    def __init__(self, op, x1, x2, chans=None):
+        if not chans:
+            chans = max_chans(max_chans(1, x1), x2)
+        super().__init__("Math", chans, A_RATE, "iUU", None, None, 'op', op,
+                         'x1', x1, 'x2', x2)
+
+    def rliset(self, x):
+        self.engine.send_cmd("/arco/math/rliset", 0, "if", self.id, x)
+        return self
+
+    @staticmethod
+    def add(x1, x2, chans=None):
+        return Math(MATH_OP_ADD, x1, x2, chans)
+
+    @staticmethod
+    def sub(x1, x2, chans=None):
+        return Math(MATH_OP_SUB, x1, x2, chans)
+
+    @staticmethod
+    def mult(x1, x2, chans=None, x2_init=None):
+        if x2_init is not None:
+            return Multx(x1, x2, x2_init, chans)
+        else:
+            return Math(MATH_OP_MUL, x1, x2, chans)
+
+    @staticmethod
+    def div(x1, x2, chans=None):
+        return Math(MATH_OP_DIV, x1, x2, chans)
+
+    @staticmethod
+    def max(x1, x2, chans=None):
+        return Math(MATH_OP_MAX, x1, x2, chans)
+
+    @staticmethod
+    def min(x1, x2, chans=None):
+        return Math(MATH_OP_MIN, x1, x2, chans)
+
+    @staticmethod
+    def clip(x1, x2, chans=None):
+        return Math(MATH_OP_CLP, x1, x2, chans)
+
+    @staticmethod
+    def pow(x1, x2, chans=None):
+        return Math(MATH_OP_POW, x1, x2, chans)
+
+    @staticmethod
+    def less(x1, x2, chans=None):
+        return Math(MATH_OP_LT, x1, x2, chans)
+
+    @staticmethod
+    def greater(x1, x2, chans=None):
+        return Math(MATH_OP_GT, x1, x2, chans)
+
+    @staticmethod
+    def soft_clip(x1, x2, chans=None):
+        return Math(MATH_OP_SCP, x1, x2, chans)
+
+    @staticmethod
+    def powi(x1, x2, chans=None):
+        return Math(MATH_OP_PWI, x1, x2, chans)
+
+    @staticmethod
+    def rand(x1, x2, chans=None):
+        return Math(MATH_OP_RND, x1, x2, chans)
+
+    @staticmethod
+    def sample_hold(x1, x2, chans=None):
+        return Math(MATH_OP_SH, x1, x2, chans)
+
+    @staticmethod
+    def quantize(x1, x2, chans=None):
+        return Math(MATH_OP_QNT, x1, x2, chans)
+
+    @staticmethod
+    def rli(x1, x2, chans=None):
+        return Math(MATH_OP_RLI, x1, x2, chans)
+
+    @staticmethod
+    def hzdiff(x1, x2, chans=None):
+        return Math(MATH_OP_HZDIFF, x1, x2, chans)
+
+    @staticmethod
+    def tan(x1, x2, chans=None):
+        return Math(MATH_OP_TAN, x1, x2, chans)
+
+    @staticmethod
+    def atan2(x1, x2, chans=None):
+        return Math(MATH_OP_ATAN2, x1, x2, chans)
+
+    @staticmethod
+    def sin(x1, x2, chans=None):
+        return Math(MATH_OP_SIN, x1, x2, chans)
+
+    @staticmethod
+    def cos(x1, x2, chans=None):
+        return Math(MATH_OP_COS, x1, x2, chans)
+
+
+class Mathb(Ugen):
+
+    def __init__(self, op, x1, x2, chans=None):
+        if not isinstance(x1, (int, float)) and x1.rate != B_RATE:
+            print("ERROR: 'x1' input to Ugen 'mathb' must be block rate", op,
+                  x1)
+            return
+        elif not isinstance(x2, (int, float)) and x2.rate != B_RATE:
+            print("ERROR: 'x2' input to Ugen 'mathb' must be block rate", op,
+                  x2)
+            return
+        else:
+            chans = chans or max_chans(max_chans(1, x1), x2)
+            super().__init__("Mathb", chans, B_RATE, "iUU", None, None, 'op',
+                             op, 'x1', x1, 'x2', x2)
+
+    def rliset(self, x):
+        self.engine.send_cmd("/arco/mathb/rliset", 0, "if", self.id, x)
+        return self
+
+    @staticmethod
+    def add(x1, x2, chans=None):
+        return Mathb(MATH_OP_ADD, x1, x2, chans)
+
+    @staticmethod
+    def sub(x1, x2, chans=None):
+        return Mathb(MATH_OP_SUB, x1, x2, chans)
+
+    @staticmethod
+    def mult(x1, x2, chans=None):
+        return Mathb(MATH_OP_MUL, x1, x2, chans)
+
+    @staticmethod
+    def div(x1, x2, chans=None):
+        return Mathb(MATH_OP_DIV, x1, x2, chans)
+
+    @staticmethod
+    def max(x1, x2, chans=None):
+        return Mathb(MATH_OP_MAX, x1, x2, chans)
+
+    @staticmethod
+    def min(x1, x2, chans=None):
+        return Mathb(MATH_OP_MIN, x1, x2, chans)
+
+    @staticmethod
+    def clip(x1, x2, chans=None):
+        return Mathb(MATH_OP_CLP, x1, x2, chans)
+
+    @staticmethod
+    def pow(x1, x2, chans=None):
+        return Mathb(MATH_OP_POW, x1, x2, chans)
+
+    @staticmethod
+    def less(x1, x2, chans=None):
+        return Mathb(MATH_OP_LT, x1, x2, chans)
+
+    @staticmethod
+    def greater(x1, x2, chans=None):
+        return Mathb(MATH_OP_GT, x1, x2, chans)
+
+    @staticmethod
+    def soft_clip(x1, x2, chans=None):
+        return Mathb(MATH_OP_SCP, x1, x2, chans)
+
+    @staticmethod
+    def powi(x1, x2, chans=None):
+        return Mathb(MATH_OP_PWI, x1, x2, chans)
+
+    @staticmethod
+    def rand(x1, x2, chans=None):
+        return Mathb(MATH_OP_RND, x1, x2, chans)
+
+    @staticmethod
+    def sample_hold(x1, x2, chans=None):
+        return Mathb(MATH_OP_SH, x1, x2, chans)
+
+    @staticmethod
+    def quantize(x1, x2, chans=None):
+        return Mathb(MATH_OP_QNT, x1, x2, chans)
+
+    @staticmethod
+    def rli(x1, x2, chans=None):
+        return Mathb(MATH_OP_RLI, x1, x2, chans)
+
+    @staticmethod
+    def hzdiff(x1, x2, chans=None):
+        return Mathb(MATH_OP_HZDIFF, x1, x2, chans)
+
+    @staticmethod
+    def tan(x1, x2, chans=None):
+        return Mathb(MATH_OP_TAN, x1, x2, chans)
+
+    @staticmethod
+    def atan2(x1, x2, chans=None):
+        return Mathb(MATH_OP_ATAN2, x1, x2, chans)
+
+    @staticmethod
+    def sin(x1, x2, chans=None):
+        return Mathb(MATH_OP_SIN, x1, x2, chans)
+
+    @staticmethod
+    def cos(x1, x2, chans=None):
+        return Mathb(MATH_OP_COS, x1, x2, chans)
+
+
+class Multx(Ugen):
+
+    def __init__(self, x1, x2, x2_init, chans=None):
+        if not chans:
+            chans = max_chans(max_chans(1, x1), x2)
+        super().__init__("Multx", chans, A_RATE, "UUf", None, None, 'x1', x1,
+                         'x2', x2, 'init', x2_init)
+
+
+class Unary(Ugen):
+
+    def __init__(self, op, x1, chans=None):
+        if not chans:
+            chans = max_chans(1, x1)
+        super().__init__("Unary", chans, A_RATE, "iU", None, None, 'op', op,
+                         'x1', x1)
+
+    @staticmethod
+    def abs(x1, chans=None):
+        return Unary(UNARY_OP_ABS, x1, chans)
+
+    @staticmethod
+    def neg(x1, chans=None):
+        return Unary(UNARY_OP_NEG, x1, chans)
+
+    @staticmethod
+    def exp(x1, chans=None):
+        return Unary(UNARY_OP_EXP, x1, chans)
+
+    @staticmethod
+    def log(x1, chans=None):
+        return Unary(UNARY_OP_LOG, x1, chans)
+
+    @staticmethod
+    def log10(x1, chans=None):
+        return Unary(UNARY_OP_LOG10, x1, chans)
+
+    @staticmethod
+    def log2(x1, chans=None):
+        return Unary(UNARY_OP_LOG2, x1, chans)
+
+    @staticmethod
+    def sqrt(x1, chans=None):
+        return Unary(UNARY_OP_SQRT, x1, chans)
+
+    @staticmethod
+    def step_to_hz(x1, chans=None):
+        return Unary(UNARY_OP_STEP_TO_HZ, x1, chans)
+
+    @staticmethod
+    def hz_to_step(x1, chans=None):
+        return Unary(UNARY_OP_HZ_TO_STEP, x1, chans)
+
+    @staticmethod
+    def vel_to_linear(x1, chans=None):
+        return Unary(UNARY_OP_VEL_TO_LINEAR, x1, chans)
+
+    @staticmethod
+    def linear_to_vel(x1, chans=None):
+        return Unary(UNARY_OP_LINEAR_TO_VEL, x1, chans)
+
+    @staticmethod
+    def db_to_linear(x1, chans=None):
+        return Unary(UNARY_OP_DB_TO_LINEAR, x1, chans)
+
+    @staticmethod
+    def linear_to_db(x1, chans=None):
+        return Unary(UNARY_OP_LINEAR_TO_DB, x1, chans)
+
+
+class Unaryb(Ugen):
+
+    def __init__(self, op, x1, chans=None):
+        if not isinstance(x1, (int, float)) and x1.rate != B_RATE:
+            print("ERROR: 'x1' input to Ugen 'unaryb' must be block rate", op)
+            return
+        if not chans:
+            chans = max_chans(1, x1)
+        super().__init__("Unaryb", chans, B_RATE, "iU", None, None, 'op', op,
+                         'x1', x1)
+
+    @staticmethod
+    def abs(x1, chans=None):
+        return Unaryb(UNARY_OP_ABS, x1, chans)
+
+    @staticmethod
+    def neg(x1, chans=None):
+        return Unaryb(UNARY_OP_NEG, x1, chans)
+
+    @staticmethod
+    def exp(x1, chans=None):
+        return Unaryb(UNARY_OP_EXP, x1, chans)
+
+    @staticmethod
+    def log(x1, chans=None):
+        return Unaryb(UNARY_OP_LOG, x1, chans)
+
+    @staticmethod
+    def log10(x1, chans=None):
+        return Unaryb(UNARY_OP_LOG10, x1, chans)
+
+    @staticmethod
+    def log2(x1, chans=None):
+        return Unaryb(UNARY_OP_LOG2, x1, chans)
+
+    @staticmethod
+    def sqrt(x1, chans=None):
+        return Unaryb(UNARY_OP_SQRT, x1, chans)
+
+    @staticmethod
+    def step_to_hz(x1, chans=None):
+        return Unaryb(UNARY_OP_STEP_TO_HZ, x1, chans)
+
+    @staticmethod
+    def hz_to_step(x1, chans=None):
+        return Unaryb(UNARY_OP_HZ_TO_STEP, x1, chans)
+
+    @staticmethod
+    def vel_to_linear(x1, chans=None):
+        return Unaryb(UNARY_OP_VEL_TO_LINEAR, x1, chans)
+
+    @staticmethod
+    def linear_to_vel(x1, chans=None):
+        return Unaryb(UNARY_OP_LINEAR_TO_VEL, x1, chans)
+
+    @staticmethod
+    def db_to_linear(x1, chans=None):
+        return Unaryb(UNARY_OP_DB_TO_LINEAR, x1, chans)
+
+    @staticmethod
+    def linear_to_db(x1, chans=None):
+        return Unaryb(UNARY_OP_LINEAR_TO_DB, x1, chans)
+
+
+class Ola_pitch_shift(Ugen):
+
+    def __init__(self, input, ratio, xfade, windur, chans=1):
+        super().__init__("Olaps", chans, A_RATE, "Ufff", None, None, 'input',
+                         input, 'ratio', ratio, 'xfade', xfade, 'windur',
+                         windur)
+
+    def set_ratio(self, value):
+        self.engine.send_cmd("/arco/olaps/ratio", 0, "if", self.id, value)
+        return self
+
+    def set_xfade(self, xfade):
+        self.engine.send_cmd("/arco/olaps/xfade", 0, "if", self.id, xfade)
+        return self
+
+    def set_windur(self, windur):
+        self.engine.send_cmd("/arco/olaps/windur", 0, "if", self.id, windur)
+        return self
+
+
+class Chorddetect(Ugen):
+
+    def __init__(self, reply_addr):
+        super().__init__("Chorddetect", 0, NO_RATE, "s", None, True,
+                         'reply_addr', reply_addr)
+
+    def start(self, reply_addr):
+        self.engine.send_cmd("/arco/chorddetect/start", 0, "is", self.id,
+                        reply_addr)
+        return self
+
+    def set(self, input_name, value):
+        self.inputs['input'] = value
+        self.engine.send_cmd("/arco/chorddetect/repl_input", 0, "ii", self.id,
+                        value.id)
+        return self
+
+
+class SpectralCentroid(Ugen):
+
+    def __init__(self, reply_addr):
+        super().__init__("SpectralCentroid", 0, NO_RATE, "s", None, True,
+                         'reply_addr', reply_addr)
+
+    def start(self, reply_addr):
+        self.engine.send_cmd("/arco/spectralcentroid/start", 0, "is", self.id,
+                        reply_addr)
+        return self
+
+    def set(self, input_name, value):
+        self.inputs['input'] = value
+        self.engine.send_cmd("/arco/spectralcentroid/repl_input", 0, "ii", self.id,
+                        value.id)
+        return self
+
+
+class SpectralRolloff(Ugen):
+
+    def __init__(self, reply_addr, threshold):
+        super().__init__("SpectralRolloff", 0, NO_RATE, "sf", None, True,
+                         'reply_addr', reply_addr, 'threshold', threshold)
+
+    def start(self, reply_addr):
+        self.engine.send_cmd("/arco/spectralrolloff/start", 0, "is", self.id,
+                        reply_addr)
+        return self
+
+    def set(self, input_name, value):
+        self.inputs['input'] = value
+        self.engine.send_cmd("/arco/spectralrolloff/repl_input", 0, "ii", self.id,
+                        value.id)
+        return self
+
+
+class Stdistr(Ugen):
+
+    def __init__(self, n, width):
+        super().__init__("Stdistr", 2, A_RATE, "if", None, True, 'n', n,
+                         'width', width)
+
+    def set_gain(self, gain):
+        self.engine.send_cmd("/arco/stdistr/gain", 0, "if", self.id, gain)
+        return self
+
+    def set_width(self, width):
+        self.engine.send_cmd("/arco/stdistr/width", 0, "if", self.id, width)
+        return self
+
+    def ins(self, index, ugen):
+        self.engine.send_cmd("/arco/stdistr/ins", 0, "iii", self.id, index, ugen.id)
+        return self
+
+    def rem(self, index):
+        self.engine.send_cmd("/arco/stdistr/rem", 0, "ii", self.id, index)
+        return self
+
+
+class Flsyn(Ugen):
+
+    def __init__(self, path):
+        super().__init__("Flsyn", None, A_RATE, "s", None, True, 'path',
+                         path)  # already hard-coded as 2 channels in flsyn.h
+
+    def alloff(self, chan):
+        self.engine.send_cmd("/arco/flsyn/off", 0, "ii", self.id, chan)
+        return self
+
+    def control_change(self, chan, num, val):
+        self.engine.send_cmd("/arco/flsyn/cc", 0, "iiii", self.id, chan, num, val)
+        return self
+
+    def channel_pressure(self, chan, val):
+        self.engine.send_cmd("/arco/flsyn/cp", 0, "iii", self.id, chan, val)
+        return self
+
+    def key_pressure(self, chan, key, val):
+        self.engine.send_cmd("/arco/flsyn/kp", 0, "iiii", self.id, chan, key, val)
+        return self
+
+    def noteoff(self, chan, key):
+        self.engine.send_cmd("/arco/flsyn/noteoff", 0, "iii", self.id, chan, key)
+        return self
+
+    def noteon(self, chan, key, vel):
+        self.engine.send_cmd("/arco/flsyn/noteon", 0, "iiii", self.id, chan, key,
+                        vel)
+        return self
+
+    def pitch_bend(self, chan, bend):
+        self.engine.send_cmd("/arco/flsyn/pbend", 0, "iif", self.id, chan, bend)
+        return self
+
+    def pitch_sens(self, chan, val):
+        self.engine.send_cmd("/arco/flsyn/psens", 0, "iii", self.id, chan, val)
+        return self
+
+    def program_change(self, chan, program):
+        self.engine.send_cmd("/arco/flsyn/prog", 0, "iii", self.id, chan, program)
+        return self
+
+
+class Wavetables(Ugen):
+
+    def __init__(self, freq, amp, phase, chans, classname, rate):
+        if chans is None:
+            chans = max_chans(max_chans(1, freq), amp)
+        super().__init__(classname, chans, rate, "UUf", None, None, 'freq',
+                         freq, 'amp', amp, 'phase', phase)
+        self.address_prefix = f"/arco/{self.classname.lower()}/"  # e.g. "/arco/tableosc/"
+
+    def create_table(self, index, tlen, data, method_name):
+        params = [self.id, index]
+        type_str = "ii"
+
+        if tlen is not None:  # omit length for time-domain data
+            params.append(tlen)
+            type_str += "i"
+
+        # Add the float vector data
+        params.extend(data)
+        type_str += "f" * len(data)
+
+        self.engine.send_cmd(f"{self.address_prefix}{method_name}", 0, type_str,
+                        *params)
+        return self
+
+    def create_tas(self, index, tlen, ampspec):
+        # Create table from amplitude spectrum
+        return self.create_table(index, tlen, ampspec, "createtas")
+
+    def create_tcs(self, index, tlen, spec):
+        # Create table from complex spectrum (amplitude and phase pairs)
+        return self.create_table(index, tlen, spec, "createtcs")
+
+    def create_ttd(self, index, samps):
+        # Create table from time-domain data (table length is len(samps))
+        return self.create_table(index, None, samps, "createttd")
+
+    def borrow(self, lender):
+        self.engine.send_cmd(f"{self.address_prefix}borrow", 0, "ii", self.id,
+                        lender.id)
+        return self
+
+    def select(self, index):
+        self.engine.send_cmd(f"{self.address_prefix}sel", 0, "ii", self.id, index)
+        return self
+
+
+class Tableosc(Wavetables):
+
+    def __init__(self, freq, amp, phase=0, chans=None):
+        super().__init__(freq, amp, phase, chans, "Tableosc", A_RATE)
+
+
+class Tableoscb(Wavetables):
+
+    def __init__(self, freq, amp, phase=0, chans=None):
+        # Check rate requirements for b-rate oscillators
+        if not isinstance(freq, (int, float)) and freq.rate != 'b':
+            print("ERROR: 'freq' input to Ugen 'tableoscb' must be block rate")
+            return None
+        if not isinstance(amp, (int, float)) and amp.rate != 'b':
+            print("ERROR: 'amp' input to Ugen 'tableoscb' must be block rate")
+            return None
+        super().__init__(freq, amp, phase, chans, "Tableoscb", B_RATE)
+
+
+class Yin(Ugen):
+
+    def __init__(self, input, minstep, maxstep, hopsize, address, chans=1):
+        super().__init__("Yin", chans, A_RATE, "Uiiis", None, None, 'input',
+                         input, 'minstep', minstep, 'maxstep', maxstep,
+                         'hopsize', hopsize, 'address', address)
+
+
+class Mix(Ugen):
+
+    def __init__(self, chans=1, wrap=True):
+        super().__init__("Mix", chans, A_RATE, "i", None, None, 'wrap',
+                         1 if wrap else 0)
+
+    def ins(self, name, ugen, gain, dur=0, mode=FADE_SMOOTH):
+        if isinstance(gain, (int, float, list)):
+            gain = Const(gain, None)
+        elif gain.rate == A_RATE:
+            print("WARNING: In Mix.ins, audio-rate mix gain is not allowed.")
+            return self
+        self.inputs[name] = [name, ugen, gain]
+        self.engine.send_cmd("/arco/mix/ins", 0, "isiifi", self.id, str(name),
+                        ugen.id, gain.id, dur, mode)
+        return self
+
+    def rem(self, name, dur=0, mode=FADE_SMOOTH):
+        if name in self.inputs:
+            self.engine.send_cmd("/arco/mix/rem", 0, "isfi", self.id, str(name),
+                            dur, mode)
+            del self.inputs[name]
+        return self
+
+    def find_name_of(self, ugen):
+        for key, val in self.inputs.items():
+            if isinstance(val, list) and val[1] == ugen:
+                return key
+        return None
+
+    def set_gain(self, name, gain, chan=0):
+        if name not in self.inputs:
+            print("ERROR: Mix.set_gain() cannot find input", name)
+            return self
+        entry = self.inputs[name]
+        gain_ugen = entry[2]
+        if isinstance(gain_ugen, Ugen) and gain_ugen.rate == C_RATE:
+            if chan >= gain_ugen.chans:
+                print("WARNING: In Mix.set_gain(), gain for", name, "is a",
+                      gain_ugen.chans, "channel Const, but set_gain requests"
+                      " channel", chan)
+            self.engine.send_cmd("/arco/mix/set_gain", 0, "isif", self.id,
+                            str(name), chan, gain)
+        else:
+            if isinstance(gain, (int, float, list)):
+                gain = Const(gain, None)
+            elif gain.rate == A_RATE:
+                print("WARNING: In Mix.set_gain(), audio-rate mix gain"
+                      " will be downsampled and then interpolated")
+            entry[2] = gain
+            self.engine.send_cmd("/arco/mix/repl_gain", 0, "isi", self.id,
+                            str(name), gain.id)
+        return self
+
+
+class Add(Ugen):
+
+    def __init__(self, chans=1, wrap=True):
+        super().__init__("Add", chans, A_RATE, "i", None, None, 'wrap',
+                         1 if wrap else 0)
+
+    def ins(self, *ugens):
+        for ugen in ugens:
+            self.engine.send_cmd("/arco/add/ins", 0, "ii", self.id, ugen.id)
+        return self
+
+    def rem(self, ugen):
+        self.engine.send_cmd("/arco/add/rem", 0, "ii", self.id, ugen.id)
+        return self
+
+    def swap(self, ugen, replacement):
+        self.engine.send_cmd("/arco/add/swap", 0, "iii", self.id, ugen.id,
+                        replacement.id)
+        return self
+
+
+class Addb(Ugen):
+
+    def __init__(self, chans=1, wrap=True):
+        super().__init__("Addb", chans, B_RATE, "i", None, None, 'wrap',
+                         1 if wrap else 0)
+
+    def ins(self, ugen):
+        self.engine.send_cmd("/arco/addb/ins", 0, "ii", self.id, ugen.id)
+        return self
+
+    def rem(self, ugen):
+        self.engine.send_cmd("/arco/addb/rem", 0, "ii", self.id, ugen.id)
+        return self
+
+    def swap(self, ugen, replacement):
+        self.engine.send_cmd("/arco/addb/swap", 0, "iii", self.id, ugen.id,
+                        replacement.id)
+        return self
+
+
+class Onset(Ugen):
+
+    def __init__(self, input, reply_addr):
+        super().__init__("Onset", 0, A_RATE, "Us", None, True, 'input', input,
+                         'reply_addr', reply_addr)
+
+
+class Zero(Ugen):
+
+    def __init__(self, id_num=None):
+        super().__init__("Zero", 1, A_RATE, "", omit_chans=True,
+                         id_num=id_num)
+
+
+class Zerob(Ugen):
+
+    def __init__(self, id_num=None):
+        super().__init__("Zerob", 1, B_RATE, "", omit_chans=True,
+                         id_num=id_num)
+
+
+# Import auto-generated ugen wrappers (overrides hand-written versions if present)
+try:
+    from arco_generated import *
+except ImportError:
+    pass  # generated wrappers not yet built


### PR DESCRIPTION
## Summary

- Adds `pyarco/` — pure-Python control bindings for Arco using o2litepy, parallel to the Serpent bindings in `serpent/srp/`
- `ArcoEngine` class manages connection lifecycle, UgenID pool, and a registry of live ugen shadows (preventing accidental GC from sending premature `/arco/free`)
- ~50 ugen wrapper classes mirroring the Serpent API, plus the Instrument/Synth/Note/Score framework
- NiceGUI interactive demo app at `apps/test/python/init.py`

## Module layout

| File | Role |
|------|------|
| `pyarco/arco_engine.py` | ArcoEngine, UgenID pool, action system, constants, utilities |
| `pyarco/arco_ugens.py` | Ugen base class and all concrete wrappers |
| `pyarco/arco_instr.py` | Instrument framework (Param, Synth, Note/Score, Reverb, Supersaw) |
| `pyarco/arco.py` | Re-export layer — `from arco import Sine` works |
| `apps/test/python/init.py` | NiceGUI demo for interactive testing |

## Test plan

- [ ] Start Arco server (`source apps/common/setpath.sh && cd apps/test && ./daserpent.app/Contents/MacOS/daserpent`)
- [ ] Run demo app (`cd apps/test/python && python init.py`)
- [ ] Verify Connect, play/mute Sine, test fade in/out
- [ ] Verify ugen cleanup on engine close (no leaked IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)